### PR TITLE
Prepare stacks as preprocessing step

### DIFF
--- a/src/miss_alignment/prepare_stacks.py
+++ b/src/miss_alignment/prepare_stacks.py
@@ -1,0 +1,148 @@
+"""Stack preparation utilities for tilt series.
+
+This module provides functionality to load raw tilt images and create
+preprocessed tilt stacks ready for training.
+"""
+
+from concurrent.futures import ProcessPoolExecutor
+from functools import partial
+from pathlib import Path
+
+import mrcfile
+from tqdm import tqdm
+from warpylib import TiltSeries
+from warpylib.movie import Movie
+
+
+def _get_original_pixel_size(tilt_series: TiltSeries) -> float:
+    """Get original pixel size from the first tilt image's MRC header.
+
+    Parameters
+    ----------
+    tilt_series : TiltSeries
+        The tilt series object containing movie paths and metadata.
+
+    Returns
+    -------
+    float
+        Original pixel size in Angstroms.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the first tilt image is not found.
+    ValueError
+        If pixel size cannot be determined from the header.
+    """
+    if len(tilt_series.tilt_movie_paths) == 0:
+        raise ValueError("Tilt series has no movie paths")
+
+    first_tilt_path = tilt_series.tilt_movie_paths[0]
+    full_path = str(
+        Path(tilt_series.data_directory_name or tilt_series.processing_directory_name)
+        / first_tilt_path
+    )
+    movie = Movie(path=full_path)
+    average_path = movie.average_path
+
+    if not Path(average_path).exists():
+        raise FileNotFoundError(f"Average image not found: {average_path}")
+
+    with mrcfile.open(average_path, mode="r", permissive=True) as mrc:
+        voxel_size = mrc.voxel_size
+        # voxel_size is a numpy recarray with x, y, z fields
+        pixel_size = float(voxel_size.x)
+
+    if pixel_size <= 0:
+        raise ValueError(
+            f"Invalid pixel size {pixel_size} in MRC header for {average_path}"
+        )
+
+    return pixel_size
+
+
+def _prepare_single_tilt_series(xml_path: Path, desired_pixel_size: float) -> None:
+    """Load raw tilt images and create tilt stack for a single tilt series.
+
+    Parameters
+    ----------
+    xml_path : Path
+        Path to the tilt series XML metadata file.
+    desired_pixel_size : float
+        Desired pixel size in Angstroms for the output stack.
+
+    Raises
+    ------
+    FileNotFoundError
+        If required image files are not found.
+    ValueError
+        If pixel size cannot be determined or other validation fails.
+    """
+    ts = TiltSeries(xml_path)
+    original_pixel_size = _get_original_pixel_size(ts)
+
+    images, _, _ = ts.load_images(
+        original_pixel_size=original_pixel_size,
+        desired_pixel_size=desired_pixel_size,
+        use_denoised=False,
+        load_averages=True,
+        load_half_averages=False,
+    )
+
+    ts.stack_tilts(
+        tilt_data=images,
+        pixel_size=desired_pixel_size,
+        create_thumbnails=True,
+    )
+
+
+def prepare_stacks_parallel(
+    training_directory: Path,
+    desired_pixel_size: float,
+    n_processes: int = 4,
+) -> None:
+    """Prepare tilt stacks for all tilt series in the training directory.
+
+    This function loads raw tilt images for each tilt series, rescales them
+    to the desired pixel size, and creates aligned tilt stacks with thumbnails.
+
+    Parameters
+    ----------
+    training_directory : Path
+        Directory containing tilt series XML files.
+    desired_pixel_size : float
+        Desired pixel size in Angstroms for the output stacks.
+    n_processes : int
+        Number of parallel processes to use. Default is 4.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no XML files are found in the training directory.
+    RuntimeError
+        If any tilt series fails to process (terminates on first error).
+    """
+    xml_files = list(training_directory.glob("*.xml"))
+    if not xml_files:
+        raise FileNotFoundError(
+            f"No XML files found in training directory: {training_directory}"
+        )
+
+    print(
+        f"Preparing stacks for {len(xml_files)} tilt series at {desired_pixel_size} Å"
+    )
+
+    # Use partial to bind the desired_pixel_size argument
+    process_func = partial(
+        _prepare_single_tilt_series, desired_pixel_size=desired_pixel_size
+    )
+
+    with ProcessPoolExecutor(max_workers=n_processes) as executor:
+        # Submit all tasks and wrap with tqdm for progress
+        futures = [executor.submit(process_func, xml_path) for xml_path in xml_files]
+
+        for future in tqdm(futures, desc="Preparing stacks", unit="tilt series"):
+            # This will raise any exception that occurred in the worker
+            future.result()
+
+    print(f"Successfully prepared stacks for {len(xml_files)} tilt series")

--- a/src/miss_alignment/prepare_stacks.py
+++ b/src/miss_alignment/prepare_stacks.py
@@ -5,7 +5,6 @@ preprocessed tilt stacks ready for training.
 """
 
 from concurrent.futures import ProcessPoolExecutor
-from functools import partial
 from pathlib import Path
 
 import mrcfile
@@ -61,7 +60,9 @@ def _get_original_pixel_size(tilt_series: TiltSeries) -> float:
     return pixel_size
 
 
-def _prepare_single_tilt_series(xml_path: Path, desired_pixel_size: float) -> None:
+def _prepare_single_tilt_series(
+    xml_path: Path, desired_pixel_size: float, device: int | None
+) -> None:
     """Load raw tilt images and create tilt stack for a single tilt series.
 
     Parameters
@@ -70,6 +71,8 @@ def _prepare_single_tilt_series(xml_path: Path, desired_pixel_size: float) -> No
         Path to the tilt series XML metadata file.
     desired_pixel_size : float
         Desired pixel size in Angstroms for the output stack.
+    device : int | None
+        CUDA device index to use for GPU operations. If None, uses CPU.
 
     Raises
     ------
@@ -78,8 +81,14 @@ def _prepare_single_tilt_series(xml_path: Path, desired_pixel_size: float) -> No
     ValueError
         If pixel size cannot be determined or other validation fails.
     """
+    import torch
+
+    if device is not None and torch.cuda.is_available():
+        torch.cuda.set_device(device)
+
     ts = TiltSeries(xml_path)
     original_pixel_size = _get_original_pixel_size(ts)
+    print(f"{xml_path.stem}: original pixel size = {original_pixel_size:.4f} Å")
 
     images, _, _ = ts.load_images(
         original_pixel_size=original_pixel_size,
@@ -100,6 +109,7 @@ def prepare_stacks_parallel(
     training_directory: Path,
     desired_pixel_size: float,
     n_processes: int = 4,
+    devices: list[int] | None = None,
 ) -> None:
     """Prepare tilt stacks for all tilt series in the training directory.
 
@@ -114,6 +124,8 @@ def prepare_stacks_parallel(
         Desired pixel size in Angstroms for the output stacks.
     n_processes : int
         Number of parallel processes to use. Default is 4.
+    devices : list[int] | None
+        List of CUDA device indices to distribute work across. If None, uses CPU.
 
     Raises
     ------
@@ -132,14 +144,15 @@ def prepare_stacks_parallel(
         f"Preparing stacks for {len(xml_files)} tilt series at {desired_pixel_size} Å"
     )
 
-    # Use partial to bind the desired_pixel_size argument
-    process_func = partial(
-        _prepare_single_tilt_series, desired_pixel_size=desired_pixel_size
-    )
-
     with ProcessPoolExecutor(max_workers=n_processes) as executor:
-        # Submit all tasks and wrap with tqdm for progress
-        futures = [executor.submit(process_func, xml_path) for xml_path in xml_files]
+        # Submit all tasks with round-robin device assignment
+        futures = []
+        for i, xml_path in enumerate(xml_files):
+            device = devices[i % len(devices)] if devices else None
+            future = executor.submit(
+                _prepare_single_tilt_series, xml_path, desired_pixel_size, device
+            )
+            futures.append(future)
 
         for future in tqdm(futures, desc="Preparing stacks", unit="tilt series"):
             # This will raise any exception that occurred in the worker

--- a/src/miss_alignment/prepare_stacks.py
+++ b/src/miss_alignment/prepare_stacks.py
@@ -88,7 +88,7 @@ def _prepare_single_tilt_series(
 
     ts = TiltSeries(xml_path)
     original_pixel_size = _get_original_pixel_size(ts)
-    print(f"{xml_path.stem}: original pixel size = {original_pixel_size:.4f} Å")
+    #print(f"{xml_path.stem}: original pixel size = {original_pixel_size:.4f} Å")
 
     images, _, _ = ts.load_images(
         original_pixel_size=original_pixel_size,

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from shutil import copyfile
+from typing import Optional
 import yaml
 
 import typer
@@ -14,6 +15,7 @@ from .data.shift_generation import create_default_generator
 from .models import MissAlignment, MAEarlyStopping
 from .alignment import run_alignment_parallel
 from .data._pool_monitor import SimplePoolMonitor
+from .prepare_stacks import prepare_stacks_parallel
 
 
 @cli.command(name="train", no_args_is_help=True)
@@ -24,6 +26,12 @@ def train_miss_align(
     pool_size: int = 1000,
     start_at_iteration: int = 0,
     monitor_production_and_consumption: bool = False,
+    prepare_stacks: Optional[float] = typer.Option(
+        None,
+        help="Pixel size (in Angstroms) for preprocessing tilt stacks. "
+        "If provided, loads raw tilt images, rescales to this pixel size, "
+        "and creates tilt stacks with thumbnails before training.",
+    ),
 ) -> None:
     """Train MissAlignment on a dataset using configuration from a YAML file."""
 
@@ -65,6 +73,16 @@ def train_miss_align(
     # track the path to the dataset
     training_directory = Path(general_config["training_directory"])
     training_directory.mkdir(exist_ok=True, parents=True)
+
+    # Prepare tilt stacks if requested
+    if prepare_stacks is not None:
+        if prepare_stacks <= 0:
+            raise ValueError("--prepare-stacks must be a positive non-zero number")
+        prepare_stacks_parallel(
+            training_directory=training_directory,
+            desired_pixel_size=prepare_stacks,
+            n_processes=4,
+        )
 
     # Set up training environment
     torch.set_float32_matmul_precision("medium")

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -82,6 +82,7 @@ def train_miss_align(
             training_directory=training_directory,
             desired_pixel_size=prepare_stacks,
             n_processes=4,
+            devices=devices_list,
         )
 
     # Set up training environment


### PR DESCRIPTION
I'd like to remove the dependency on pre-made stacks to bring Miss closer to a single-step tool once we add correlation-based pre-alignment. I started writing a WarpTools wrapper and realized that it would be very impractical to deal with 2 Python environments in a single process (launching Miss as a sub-process from WT). It's a different situation with etomo/AreTomo because they don't need separate Python environments.