### PR TITLE
always apply anchoring to ensure we check new initial states

### DIFF
--- a/src/miss_alignment/alignment/optimize_global.py
+++ b/src/miss_alignment/alignment/optimize_global.py
@@ -494,7 +494,6 @@ def _optimize_shifts_inner(
         # Apply the correction: subtract the projected delta shift from all tilts
         tilt_series.tilt_axis_offset_y -= shifts_2d[:, 0]
         tilt_series.tilt_axis_offset_x -= shifts_2d[:, 1]
-        print(tilt_series.tilt_axis_offset_y[zero_tilt_idx], tilt_series.tilt_axis_offset_x[zero_tilt_idx])
     elif len(setting) == 2:
         # remove gradients
         tilt_series.grid_movement_x.values = tilt_series.grid_movement_x.values.detach()

--- a/src/miss_alignment/alignment/optimize_global.py
+++ b/src/miss_alignment/alignment/optimize_global.py
@@ -11,6 +11,7 @@ import torch
 from warpylib import TiltSeries
 from warpylib.cubic_grid import CubicGrid
 from torch_affine_utils.transforms_3d import Ry, Rz
+from torch_affine_utils.transforms_2d import R
 
 from miss_alignment.models import MissAlignment
 from miss_alignment.alignment.utils import project_volume_shift_to_image_alignment
@@ -461,6 +462,16 @@ def _optimize_shifts_inner(
         # Calculate the difference from initial to current at zero tilt
         delta_shift_y = current_zero_tilt_shift_y - initial_zero_tilt_shift_y
         delta_shift_x = current_zero_tilt_shift_x - initial_zero_tilt_shift_x
+        
+        delta_shift_2d = torch.tensor(
+            [delta_shift_y, delta_shift_x],
+            device=device,
+            dtype=tilt_series.angles.dtype,
+        )
+        m_2d = R(tilt_series.tilt_axis_angles, yx=True)
+        m_2d = torch.linalg.inv(m_2d[zero_tilt_idx, :2, :2])
+        delta_shift_2d = m_2d @ einops.rearrange(delta_shift_2d, 'x -> x 1')
+        delta_shift_y, delta_shift_x = delta_shift_2d[0], delta_shift_2d[1]        
 
         # Create a 3D shift tensor with z=0 (in ZYX order)
         shift_3d = torch.tensor(
@@ -483,6 +494,7 @@ def _optimize_shifts_inner(
         # Apply the correction: subtract the projected delta shift from all tilts
         tilt_series.tilt_axis_offset_y -= shifts_2d[:, 0]
         tilt_series.tilt_axis_offset_x -= shifts_2d[:, 1]
+        print(tilt_series.tilt_axis_offset_y[zero_tilt_idx], tilt_series.tilt_axis_offset_x[zero_tilt_idx])
     elif len(setting) == 2:
         # remove gradients
         tilt_series.grid_movement_x.values = tilt_series.grid_movement_x.values.detach()

--- a/src/miss_alignment/alignment/optimize_iterative.py
+++ b/src/miss_alignment/alignment/optimize_iterative.py
@@ -7,15 +7,13 @@ relative offsets of unreliable tilts.
 
 import os
 from typing import Callable
-
+from warpylib import TiltSeries
 import torch
 
-_DEBUG = os.environ.get("MISS_DEBUG", "").lower() in ("1", "true", "yes")
-from warpylib import TiltSeries
-
 from miss_alignment.models import MissAlignment
-
 from .optimize_global import optimize_shifts
+
+_DEBUG = os.environ.get("MISS_DEBUG", "").lower() in ("1", "true", "yes")
 
 
 def run_iterative_anchoring(
@@ -113,49 +111,52 @@ def run_iterative_anchoring(
         if _DEBUG:
             print(f"Loss went from {loss_values[0]} to {current_loss}")
 
-        # Check for worse loss - immediately revert if so
+        # Check if optimization improved
         if current_loss >= best_loss:
             if _DEBUG:
                 print(
-                    f"  -> Loss worse ({current_loss:.4f} >= {best_loss:.4f}), reverting"
+                    f"  -> Loss worse ({current_loss:.4f} >= "
+                    f"{best_loss:.4f}), reverting"
                 )
-            # Restore best solution and skip anchoring restoration
+            # Restore best solution
             tilt_series.tilt_axis_offset_x = best_offsets_x.clone()
             tilt_series.tilt_axis_offset_y = best_offsets_y.clone()
         else:
-            # New best - update and apply anchoring restoration
+            # New best - update best loss and offsets (before anchoring)
             best_loss = current_loss
             best_offsets_x = tilt_series.tilt_axis_offset_x.clone()
             best_offsets_y = tilt_series.tilt_axis_offset_y.clone()
             if _DEBUG:
                 print(f"  -> New best loss: {best_loss:.4f}")
 
-            # Restore unreliable tilts with chain-like relative offsets
-            # Negative side: propagate from boundary outward (high sorted idx to low)
-            for i in range(n_unreliable_per_side - 1, -1, -1):
-                curr_tilt_idx = sorted_indices[i]
-                next_tilt_idx = sorted_indices[i + 1]
-                tilt_series.tilt_axis_offset_x[curr_tilt_idx] = (
-                    tilt_series.tilt_axis_offset_x[next_tilt_idx]
-                    + neg_relative_offsets_x[i]
-                )
-                tilt_series.tilt_axis_offset_y[curr_tilt_idx] = (
-                    tilt_series.tilt_axis_offset_y[next_tilt_idx]
-                    + neg_relative_offsets_y[i]
-                )
+        # ALWAYS apply anchoring restoration to ensure unreliable tilts
+        # maintain their structure relative to the current iteration's reliable set
+        # Restore unreliable tilts with chain-like relative offsets
+        # Negative side: propagate from boundary outward (high sorted idx to low)
+        for i in range(n_unreliable_per_side - 1, -1, -1):
+            curr_tilt_idx = sorted_indices[i]
+            next_tilt_idx = sorted_indices[i + 1]
+            tilt_series.tilt_axis_offset_x[curr_tilt_idx] = (
+                tilt_series.tilt_axis_offset_x[next_tilt_idx]
+                + neg_relative_offsets_x[i]
+            )
+            tilt_series.tilt_axis_offset_y[curr_tilt_idx] = (
+                tilt_series.tilt_axis_offset_y[next_tilt_idx]
+                + neg_relative_offsets_y[i]
+            )
 
-            # Positive side: propagate from boundary outward (low sorted idx to high)
-            for i, sorted_i in enumerate(range(pos_boundary_sorted_idx + 1, n_tilts)):
-                curr_tilt_idx = sorted_indices[sorted_i]
-                prev_tilt_idx = sorted_indices[sorted_i - 1]
-                tilt_series.tilt_axis_offset_x[curr_tilt_idx] = (
-                    tilt_series.tilt_axis_offset_x[prev_tilt_idx]
-                    + pos_relative_offsets_x[i]
-                )
-                tilt_series.tilt_axis_offset_y[curr_tilt_idx] = (
-                    tilt_series.tilt_axis_offset_y[prev_tilt_idx]
-                    + pos_relative_offsets_y[i]
-                )
+        # Positive side: propagate from boundary outward (low sorted idx to high)
+        for i, sorted_i in enumerate(range(pos_boundary_sorted_idx + 1, n_tilts)):
+            curr_tilt_idx = sorted_indices[sorted_i]
+            prev_tilt_idx = sorted_indices[sorted_i - 1]
+            tilt_series.tilt_axis_offset_x[curr_tilt_idx] = (
+                tilt_series.tilt_axis_offset_x[prev_tilt_idx]
+                + pos_relative_offsets_x[i]
+            )
+            tilt_series.tilt_axis_offset_y[curr_tilt_idx] = (
+                tilt_series.tilt_axis_offset_y[prev_tilt_idx]
+                + pos_relative_offsets_y[i]
+            )
 
         # Expand reliable set by 1 tilt per side
         n_unreliable_per_side -= 1


### PR DESCRIPTION
I was reading the anchoring code and noticed it might get stuck in an unproductive loop. Before, if the current loss was >= than best loss, we would restore the alignment from best_loss and run again. This meant we are just rerunning the optimization with the exact same alignment. Now, I moved the anchoring restoration to after the if..else statement to ensure we always try a new set of initial alignments by anchoring the current fraction of unreliable tilts to the previous best alignments.

From what I tested the loss does drop further with this code.