### PR TITLE
add distributed parallel training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "torch-fourier-slice>=0.3.1",
     "torch-fourier-shift>=0.0.4",
     "torch-fourier-filter",
-    "torch-tiltxcorr>=0.0.5",
+    "torch-tiltxcorr==0.1.4",
     "torch-cubic-spline-grids",
     "torch-grid-utils>=0.0.5",
     "torch-tomogram",

--- a/src/miss_alignment/alignment/parallel.py
+++ b/src/miss_alignment/alignment/parallel.py
@@ -99,7 +99,9 @@ def run_alignment_parallel(
         )
 
     results = []
-    with mp.Manager() as manager:
+    # Use explicit spawn context to avoid CUDA issues with fork
+    ctx = mp.get_context("spawn")
+    with ctx.Manager() as manager:
         task_queue = (
             manager.Queue()
         )  # the list of tasks where processes can get there next task from
@@ -113,7 +115,7 @@ def run_alignment_parallel(
         # if a device occurs multiple times in devices_list,
         # use it only once to keep memory footprint deterministic per GPU
         procs = [
-            mp.Process(
+            ctx.Process(
                 target=gpu_runner,
                 args=(
                     "cuda:" + str(g),

--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -93,13 +93,15 @@ def _count_partition_files(pool_dir: Path, partition_id: int) -> int:
     """Count the number of files in a partition.
 
     Files are named: partition_{partition_id}_worker_{worker_id}_seq_{seq_id}.pickle
+    All workers write to all partitions, so we count files from all workers.
     """
-    pattern = f"partition_{partition_id}_worker_*.pickle"
+    pattern = f"partition_{partition_id}_worker_*_seq_*.pickle"
     return len(list(pool_dir.glob(pattern)))
 
 
 def reconstruction_worker(
-    partition_id: int,
+    worker_id: int,
+    n_partitions: int,
     partition_size: int,
     pool_dir: Path,
     tilt_series_xmls: list[Path],
@@ -112,14 +114,19 @@ def reconstruction_worker(
     device: str | torch.device = "cpu",
 ):
     """
-    Worker process that maintains a partition of the reconstruction pool.
+    Worker process that cycles through all partitions of the reconstruction pool.
+
+    Each worker writes to all partitions in round-robin order. File names include
+    the worker_id to ensure uniqueness across workers.
 
     Parameters
     ----------
-    partition_id : int
-        ID of this worker's partition
+    worker_id : int
+        Unique ID of this worker (used in file naming for uniqueness)
+    n_partitions : int
+        Total number of partitions to cycle through
     partition_size : int
-        Maximum number of files to maintain in this partition
+        Maximum number of files to maintain per partition
     pool_dir : Path
         Directory to store reconstructions
     tilt_series_xmls : list[Path]
@@ -144,8 +151,8 @@ def reconstruction_worker(
     torch.set_num_threads(1)
 
     print(
-        f"Reconstruction worker {partition_id} "
-        f"starting (partition size: {partition_size})"
+        f"Reconstruction worker {worker_id} starting "
+        f"(cycling through {n_partitions} partitions, {partition_size} files each)"
     )
 
     # Initialize tilt series fetcher
@@ -157,17 +164,25 @@ def reconstruction_worker(
         device=device,
     )
 
-    # Sequential ID counter for this partition
+    # Sequential ID counter for this worker (unique per worker)
     sequential_id = 0
+    # Current partition index (cycles through 0 to n_partitions-1)
+    current_partition = 0
 
     # Continuously generate reconstructions
     while not stop_event.is_set():
-        # Check if partition is full, pause if so
-        while _count_partition_files(pool_dir, partition_id) >= partition_size:
-            if stop_event.is_set():
-                print(f"Reconstruction worker {partition_id} shutting down")
-                return
-            time.sleep(PAUSE_POLL_INTERVAL)
+        # Check if current partition is full, if so try next partition
+        partitions_checked = 0
+        while _count_partition_files(pool_dir, current_partition) >= partition_size:
+            current_partition = (current_partition + 1) % n_partitions
+            partitions_checked += 1
+            # If all partitions are full, wait
+            if partitions_checked >= n_partitions:
+                if stop_event.is_set():
+                    print(f"Reconstruction worker {worker_id} shutting down")
+                    return
+                time.sleep(PAUSE_POLL_INTERVAL)
+                partitions_checked = 0
 
         # Generate reconstruction and 8 mirrored triplets
         tilt_series, images, pixel_size = tilt_series_fetcher()
@@ -189,12 +204,15 @@ def reconstruction_worker(
                 triplet_fp16 = [(vol.half(), label) for vol, label in triplet]
 
                 # Write with atomic rename
-                file_path = (
-                    pool_dir / f"partition_{partition_id}_seq_{sequential_id}.pickle"
+                # File name includes worker_id for uniqueness across workers
+                filename = (
+                    f"partition_{current_partition}_worker_{worker_id}"
+                    f"_seq_{sequential_id}.pickle"
                 )
+                file_path = pool_dir / filename
                 with tempfile.NamedTemporaryFile(
                     dir=pool_dir,
-                    prefix=f"tmp_partition_{partition_id}_",
+                    prefix=f"tmp_partition_{current_partition}_worker_{worker_id}_",
                     suffix=".pickle",
                     delete=False,
                 ) as tmp_file:
@@ -207,7 +225,10 @@ def reconstruction_worker(
                 # Increment and wrap sequential ID
                 sequential_id = (sequential_id + 1) % MAX_SEQUENTIAL_ID
 
-    print(f"Reconstruction worker {partition_id} shutting down")
+                # Move to next partition (round-robin)
+                current_partition = (current_partition + 1) % n_partitions
+
+    print(f"Reconstruction worker {worker_id} shutting down")
 
 
 def sample_positions(

--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -90,8 +90,11 @@ class TiltSeriesFetcher:
 
 
 def _count_partition_files(pool_dir: Path, partition_id: int) -> int:
-    """Count the number of files in a partition."""
-    pattern = f"partition_{partition_id}_*.pickle"
+    """Count the number of files in a partition.
+
+    Files are named: partition_{partition_id}_worker_{worker_id}_seq_{seq_id}.pickle
+    """
+    pattern = f"partition_{partition_id}_worker_*.pickle"
     return len(list(pool_dir.glob(pattern)))
 
 

--- a/src/miss_alignment/data/training_datamodule.py
+++ b/src/miss_alignment/data/training_datamodule.py
@@ -1,7 +1,8 @@
 # standard libraries
-import os
+import hashlib
 import multiprocessing as mp
 import shutil
+import tempfile
 from pathlib import Path
 from collections.abc import Callable
 from typing import Optional
@@ -13,21 +14,7 @@ from torch.utils.data import DataLoader
 
 from ._reconstruction_worker import reconstruction_worker
 from .training_dataset import ReconstructionPoolDataset
-
-
-def _is_rank_zero() -> bool:
-    """Check if we're on the main process (rank 0) in DDP.
-
-    This checks both torch.distributed (if initialized) and the LOCAL_RANK
-    environment variable (set by DDP launchers before script execution).
-    """
-    if torch.distributed.is_initialized():
-        return torch.distributed.get_rank() == 0
-    # Check LOCAL_RANK env var (set by DDP launcher before torch.distributed init)
-    local_rank = os.environ.get("LOCAL_RANK")
-    if local_rank is not None:
-        return int(local_rank) == 0
-    return True
+from ..utils import is_rank_zero
 
 
 # Default pool size
@@ -37,12 +24,11 @@ DEFAULT_POOL_SIZE = 1000
 def _worker_init_fn(worker_id: int):
     """Initialize DataLoader worker with its partition ID.
 
-    Calculates global partition assignment for multi-GPU DDP training:
-    - global_worker_id = global_rank * num_local_workers + worker_id
-    - partition_id = global_worker_id % n_partitions
+    Each dataloader worker across all DDP ranks gets its own dedicated partition:
+    - partition_id = global_rank * num_local_workers + worker_id
 
-    This allows multiple DataLoader workers to consume from the same partition
-    when there are more consumers than producers.
+    With n_partitions = n_training_devices * dataloader_workers, each worker
+    gets exactly one partition (no sharing).
 
     Note: global_rank is obtained directly from torch.distributed here, not from
     the dataset. This is critical because the dataloader may be created before
@@ -60,24 +46,26 @@ def _worker_init_fn(worker_id: int):
         else:
             global_rank = 0
         num_local_workers = worker_info.num_workers
-        n_partitions = dataset.n_partitions
 
-        global_worker_id = global_rank * num_local_workers + worker_id
-        dataset.partition_id = global_worker_id % n_partitions
+        # Each dataloader worker gets its own partition
+        # partition_id = global_rank * num_local_workers + worker_id
+        dataset.partition_id = global_rank * num_local_workers + worker_id
 
 
 class MissAlignmentDataModule(pl.LightningDataModule):
     """
     Training datamodule with reconstruction workers and DataLoader consumers.
 
-    Reconstruction workers write to partitioned pool directories. DataLoader
-    workers consume from these partitions. Multiple DataLoader workers can
-    share a partition (they race to grab files, with retry logic handling
-    conflicts).
+    Reconstruction workers cycle through all partitions, writing to each in
+    round-robin order. Each DataLoader worker (across all DDP ranks) gets
+    its own dedicated partition.
 
-    For multi-GPU DDP training, partition assignment is global:
-        global_worker_id = global_rank * dataloader_workers + local_worker_id
-        partition_id = global_worker_id % n_workers
+    Partitioning scheme:
+        n_partitions = n_training_devices * dataloader_workers
+        partition_id = global_rank * dataloader_workers + local_worker_id
+
+    File naming:
+        partition_{partition_id}_worker_{worker_id}_seq_{sequential_id}.pickle
 
     Directory layout:
 
@@ -96,10 +84,12 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         Directory containing tilt series JSON files
     shift_generator : Callable
         Function that generates synthetic alignment shifts
-    n_workers : int
-        Number of reconstruction workers (each writes to its own partition)
     reconstruction_accelerators : list[int]
-        GPU device IDs for reconstruction workers (one per worker)
+        GPU device IDs for reconstruction workers. The number of workers is
+        determined by the length of this list. Devices can be repeated to run
+        multiple workers per GPU (e.g., [0, 0, 1, 1]).
+    n_training_devices : int
+        Number of training devices (GPUs) used for DDP training
     batch_size : int, default 4
         Batch size for training (per device in DDP)
     steps_per_epoch : int, default 1000
@@ -113,16 +103,15 @@ class MissAlignmentDataModule(pl.LightningDataModule):
     pool_size : int, default 1000
         Total size of reconstruction pool (divided among partitions)
     dataloader_workers : int, default 2
-        Number of CPU DataLoader workers per training device. Can exceed
-        n_workers; multiple DataLoader workers will share partitions.
+        Number of CPU DataLoader workers per training device.
     """
 
     def __init__(
         self,
         dataset_directory,
         shift_generator: Callable,
-        n_workers: int,
         reconstruction_accelerators: list[int],
+        n_training_devices: int,
         batch_size: int = 4,
         steps_per_epoch: int = 1000,
         patch_size: int = 64,
@@ -132,35 +121,34 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         dataloader_workers: int = 2,
     ):
         super().__init__()
+
+        # Validate reconstruction accelerators
+        if not reconstruction_accelerators:
+            raise ValueError("reconstruction_accelerators cannot be empty")
+
+        # Number of workers is determined by the accelerators list
+        self.n_workers = len(reconstruction_accelerators)
+        self.reconstruction_devices = [f"cuda:{x}" for x in reconstruction_accelerators]
+
         # data module controls
         self.batch_size = batch_size
         self.epoch_size = steps_per_epoch * batch_size
-        self.n_workers = n_workers
         self.pool_size = pool_size
         self.dataloader_workers = dataloader_workers
+        self.n_training_devices = n_training_devices
+
+        # Calculate number of partitions: one per dataloader worker across all ranks
+        self.n_partitions = n_training_devices * dataloader_workers
 
         # Validate pool size
-        self.partition_size = pool_size // n_workers
+        self.partition_size = pool_size // self.n_partitions
         if self.partition_size < 2 * batch_size:
             raise ValueError(
-                f"Pool size {pool_size} with {n_workers} workers gives "
+                f"Pool size {pool_size} with {self.n_partitions} partitions gives "
                 f"partition_size={self.partition_size}, which is less than "
                 f"2 * batch_size ({2 * batch_size}). Increase pool_size or "
-                f"decrease n_workers/batch_size."
+                f"decrease n_training_devices/dataloader_workers/batch_size."
             )
-
-        # This is an old code path that used cpu's for reconstruction
-        # we have abandonded it in favor of splitting the GPU's
-        if reconstruction_accelerators in [None, []]:
-            # self.reconstruction_devices = ["cpu"] * n_workers
-            raise NotImplementedError
-
-        # Set up reconstruction devices
-        if len(reconstruction_accelerators) != n_workers:
-            raise ValueError(
-                "Number of reconstruction accelerators must match n_workers"
-            )
-        self.reconstruction_devices = [f"cuda:{x}" for x in reconstruction_accelerators]
 
         # reconstruction controls
         self.patch_size = patch_size
@@ -206,13 +194,15 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         if self._workers_spawned:
             return
 
-        # Use a deterministic pool directory so all ranks know the path.
-        # This is placed inside the training directory to ensure all ranks
-        # can access it (important for distributed filesystems).
-        self.pool_dir = self.dataset_directory / ".recon_pool"
+        # Use a deterministic pool directory in /tmp so all DDP ranks know the path.
+        # The path is based on a hash of the training directory to avoid collisions.
+        dir_hash = hashlib.md5(
+            str(self.dataset_directory.resolve()).encode()
+        ).hexdigest()[:12]
+        self.pool_dir = Path(tempfile.gettempdir()) / f"recon_pool_{dir_hash}"
 
         # Only rank 0 spawns reconstruction workers
-        if _is_rank_zero():
+        if is_rank_zero():
             mp.set_start_method("spawn", force=True)
 
             # Clean up any existing pool directory from previous runs
@@ -220,6 +210,10 @@ class MissAlignmentDataModule(pl.LightningDataModule):
                 shutil.rmtree(self.pool_dir)
             self.pool_dir.mkdir(parents=True, exist_ok=True)
             print(f"Created pool directory: {self.pool_dir}")
+            print(
+                f"Pool configuration: {self.n_workers} workers -> "
+                f"{self.n_partitions} partitions ({self.partition_size} files each)"
+            )
 
             # Start worker processes
             self.stop_event = mp.Event()
@@ -227,11 +221,12 @@ class MissAlignmentDataModule(pl.LightningDataModule):
             # get a list of all the tilt series json files
             tilt_series_xmls = list(self.dataset_directory.glob("*.xml"))
 
-            for partition_id in range(self.n_workers):
+            for worker_id in range(self.n_workers):
                 p = mp.Process(
                     target=reconstruction_worker,
                     kwargs={
-                        "partition_id": partition_id,
+                        "worker_id": worker_id,
+                        "n_partitions": self.n_partitions,
                         "partition_size": self.partition_size,
                         "pool_dir": self.pool_dir,
                         "tilt_series_xmls": tilt_series_xmls,
@@ -241,7 +236,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
                         "shift_generator": self.shift_generator,
                         "stop_event": self.stop_event,
                         "tilt_series_refresh_rate": 10,
-                        "device": self.reconstruction_devices[partition_id],
+                        "device": self.reconstruction_devices[worker_id],
                     },
                 )
                 p.start()
@@ -257,7 +252,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
             pool_dir=self.pool_dir,
             batch_size=self.batch_size,
             epoch_size=self.epoch_size,
-            n_partitions=self.n_workers,
+            n_partitions=self.n_partitions,
         )
 
     def train_dataloader(self):
@@ -281,7 +276,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         Other ranks simply reset their local state.
         """
         # Only perform full teardown on rank 0 (where workers were spawned)
-        if _is_rank_zero():
+        if is_rank_zero():
             if self.stop_event:
                 print("Stopping reconstruction workers...")
                 self.stop_event.set()

--- a/src/miss_alignment/data/training_datamodule.py
+++ b/src/miss_alignment/data/training_datamodule.py
@@ -1,5 +1,5 @@
 # standard libraries
-import tempfile
+import os
 import multiprocessing as mp
 import shutil
 from pathlib import Path
@@ -13,6 +13,22 @@ from torch.utils.data import DataLoader
 
 from ._reconstruction_worker import reconstruction_worker
 from .training_dataset import ReconstructionPoolDataset
+
+
+def _is_rank_zero() -> bool:
+    """Check if we're on the main process (rank 0) in DDP.
+
+    This checks both torch.distributed (if initialized) and the LOCAL_RANK
+    environment variable (set by DDP launchers before script execution).
+    """
+    if torch.distributed.is_initialized():
+        return torch.distributed.get_rank() == 0
+    # Check LOCAL_RANK env var (set by DDP launcher before torch.distributed init)
+    local_rank = os.environ.get("LOCAL_RANK")
+    if local_rank is not None:
+        return int(local_rank) == 0
+    return True
+
 
 # Default pool size
 DEFAULT_POOL_SIZE = 1000
@@ -158,6 +174,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         self.pool_dir = None
         self.pool_processes: list = []
         self.stop_event: Optional[mp.Event] = None
+        self._workers_spawned = False  # Guard against duplicate worker spawning
 
     def __enter__(self):
         """Enter context manager and setup pool."""
@@ -173,44 +190,69 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         pass
 
     def setup(self, stage: str = "fit"):
-        """No stage for setup because this is used just for training."""
+        """Set up the data module for training.
+
+        This method spawns reconstruction workers (on rank 0 only) and creates
+        the dataset. All ranks share the same pool directory.
+
+        In DDP, only rank 0 spawns reconstruction workers. Other ranks skip
+        worker spawning but still create their dataset pointing to the shared
+        pool directory.
+        """
         if stage != "fit":
             raise ValueError(f"{stage} is not a valid stage")
 
-        mp.set_start_method("spawn", force=True)
+        # Guard: Only run setup once per process
+        if self._workers_spawned:
+            return
 
-        # Create temporary directory for pool
-        self.pool_dir = Path(tempfile.mkdtemp(prefix="recon_pool_"))
-        print(f"Created pool directory: {self.pool_dir}")
+        # Use a deterministic pool directory so all ranks know the path.
+        # This is placed inside the training directory to ensure all ranks
+        # can access it (important for distributed filesystems).
+        self.pool_dir = self.dataset_directory / ".recon_pool"
 
-        # Start worker processes
-        self.stop_event = mp.Event()
+        # Only rank 0 spawns reconstruction workers
+        if _is_rank_zero():
+            mp.set_start_method("spawn", force=True)
 
-        # get a list of all the tilt series json files
-        tilt_series_xmls = list(self.dataset_directory.glob("*.xml"))
+            # Clean up any existing pool directory from previous runs
+            if self.pool_dir.exists():
+                shutil.rmtree(self.pool_dir)
+            self.pool_dir.mkdir(parents=True, exist_ok=True)
+            print(f"Created pool directory: {self.pool_dir}")
 
-        for partition_id in range(self.n_workers):
-            p = mp.Process(
-                target=reconstruction_worker,
-                kwargs={
-                    "partition_id": partition_id,
-                    "partition_size": self.partition_size,
-                    "pool_dir": self.pool_dir,
-                    "tilt_series_xmls": tilt_series_xmls,
-                    "patch_size": self.patch_size,
-                    "apply_ctf": self.apply_ctf,
-                    "downsample": self.downsample,
-                    "shift_generator": self.shift_generator,
-                    "stop_event": self.stop_event,
-                    "tilt_series_refresh_rate": 10,
-                    "device": self.reconstruction_devices[partition_id],
-                },
-            )
-            p.start()
-            self.pool_processes.append(p)
+            # Start worker processes
+            self.stop_event = mp.Event()
+
+            # get a list of all the tilt series json files
+            tilt_series_xmls = list(self.dataset_directory.glob("*.xml"))
+
+            for partition_id in range(self.n_workers):
+                p = mp.Process(
+                    target=reconstruction_worker,
+                    kwargs={
+                        "partition_id": partition_id,
+                        "partition_size": self.partition_size,
+                        "pool_dir": self.pool_dir,
+                        "tilt_series_xmls": tilt_series_xmls,
+                        "patch_size": self.patch_size,
+                        "apply_ctf": self.apply_ctf,
+                        "downsample": self.downsample,
+                        "shift_generator": self.shift_generator,
+                        "stop_event": self.stop_event,
+                        "tilt_series_refresh_rate": 10,
+                        "device": self.reconstruction_devices[partition_id],
+                    },
+                )
+                p.start()
+                self.pool_processes.append(p)
+
+        # Mark setup as complete to prevent duplicate execution
+        self._workers_spawned = True
 
         # Create dataset (global_rank is obtained in worker_init_fn
-        # from torch.distributed)
+        # from torch.distributed). All ranks create their own dataset
+        # pointing to the shared pool directory.
         self.train_dataset = ReconstructionPoolDataset(
             pool_dir=self.pool_dir,
             batch_size=self.batch_size,
@@ -233,18 +275,31 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         )
 
     def teardown(self, stage: Optional[str] = None):
-        """Clean up pool and worker processes."""
-        if self.stop_event:
-            print("Stopping reconstruction workers...")
-            self.stop_event.set()
+        """Clean up pool and worker processes.
 
-            for p in self.pool_processes:
-                p.join(timeout=5.0)
-                if p.is_alive():
-                    p.terminate()
-                    p.join()
+        Only rank 0 performs cleanup since only rank 0 spawns workers.
+        Other ranks simply reset their local state.
+        """
+        # Only perform full teardown on rank 0 (where workers were spawned)
+        if _is_rank_zero():
+            if self.stop_event:
+                print("Stopping reconstruction workers...")
+                self.stop_event.set()
 
-        if self.pool_dir and self.pool_dir.exists():
-            shutil.rmtree(self.pool_dir)
-            print(f"Cleaned up pool directory: {self.pool_dir}")
-        print("Cleanup complete")
+                for p in self.pool_processes:
+                    p.join(timeout=5.0)
+                    if p.is_alive():
+                        p.terminate()
+                        p.join()
+
+            if self.pool_dir and self.pool_dir.exists():
+                shutil.rmtree(self.pool_dir)
+                print(f"Cleaned up pool directory: {self.pool_dir}")
+
+            print("Cleanup complete")
+
+        # Reset state for potential reuse (all ranks)
+        self._workers_spawned = False
+        self.pool_processes = []
+        self.stop_event = None
+        self.pool_dir = None

--- a/src/miss_alignment/data/training_datamodule.py
+++ b/src/miss_alignment/data/training_datamodule.py
@@ -203,7 +203,8 @@ class MissAlignmentDataModule(pl.LightningDataModule):
 
         # Only rank 0 spawns reconstruction workers
         if is_rank_zero():
-            mp.set_start_method("spawn", force=True)
+            # Use explicit spawn context to avoid affecting global multiprocessing state
+            ctx = mp.get_context("spawn")
 
             # Clean up any existing pool directory from previous runs
             if self.pool_dir.exists():
@@ -216,13 +217,13 @@ class MissAlignmentDataModule(pl.LightningDataModule):
             )
 
             # Start worker processes
-            self.stop_event = mp.Event()
+            self.stop_event = ctx.Event()
 
             # get a list of all the tilt series json files
             tilt_series_xmls = list(self.dataset_directory.glob("*.xml"))
 
             for worker_id in range(self.n_workers):
-                p = mp.Process(
+                p = ctx.Process(
                     target=reconstruction_worker,
                     kwargs={
                         "worker_id": worker_id,

--- a/src/miss_alignment/data/training_datamodule.py
+++ b/src/miss_alignment/data/training_datamodule.py
@@ -19,20 +19,49 @@ DEFAULT_POOL_SIZE = 1000
 
 
 def _worker_init_fn(worker_id: int):
-    """Initialize DataLoader worker with its partition ID."""
+    """Initialize DataLoader worker with its partition ID.
+
+    Calculates global partition assignment for multi-GPU DDP training:
+    - global_worker_id = global_rank * num_local_workers + worker_id
+    - partition_id = global_worker_id % n_partitions
+
+    This allows multiple DataLoader workers to consume from the same partition
+    when there are more consumers than producers.
+
+    Note: global_rank is obtained directly from torch.distributed here, not from
+    the dataset. This is critical because the dataloader may be created before
+    DDP is initialized, but worker_init_fn runs after DDP setup (workers are
+    forked from DDP processes).
+    """
     worker_info = torch.utils.data.get_worker_info()
     if worker_info is not None:
         dataset = worker_info.dataset
-        dataset.partition_id = worker_id
+        # Get global_rank directly from distributed - this works because
+        # DataLoader workers are forked AFTER DDP is initialized, so they
+        # inherit the distributed state from their parent DDP process.
+        if torch.distributed.is_initialized():
+            global_rank = torch.distributed.get_rank()
+        else:
+            global_rank = 0
+        num_local_workers = worker_info.num_workers
+        n_partitions = dataset.n_partitions
+
+        global_worker_id = global_rank * num_local_workers + worker_id
+        dataset.partition_id = global_worker_id % n_partitions
 
 
 class MissAlignmentDataModule(pl.LightningDataModule):
     """
-    Training datamodule with coupled reconstruction and data loading workers.
+    Training datamodule with reconstruction workers and DataLoader consumers.
 
-    Each reconstruction worker is paired 1:1 with a DataLoader worker, sharing
-    a partition of the pool. Reconstruction workers pause when their partition
-    is full, and DataLoader workers pause when their partition is too empty.
+    Reconstruction workers write to partitioned pool directories. DataLoader
+    workers consume from these partitions. Multiple DataLoader workers can
+    share a partition (they race to grab files, with retry logic handling
+    conflicts).
+
+    For multi-GPU DDP training, partition assignment is global:
+        global_worker_id = global_rank * dataloader_workers + local_worker_id
+        partition_id = global_worker_id % n_workers
 
     Directory layout:
 
@@ -51,12 +80,12 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         Directory containing tilt series JSON files
     shift_generator : Callable
         Function that generates synthetic alignment shifts
-    n_workers : int, default 4
-        Number of reconstruction/DataLoader worker pairs
-    reconstruction_accelerators : Optional[list[int]], default None
-        GPU device IDs for reconstruction workers
+    n_workers : int
+        Number of reconstruction workers (each writes to its own partition)
+    reconstruction_accelerators : list[int]
+        GPU device IDs for reconstruction workers (one per worker)
     batch_size : int, default 4
-        Batch size for training
+        Batch size for training (per device in DDP)
     steps_per_epoch : int, default 1000
         Number of steps per training epoch
     patch_size : int, default 64
@@ -67,6 +96,9 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         Downsampling factor for reconstructions
     pool_size : int, default 1000
         Total size of reconstruction pool (divided among partitions)
+    dataloader_workers : int, default 2
+        Number of CPU DataLoader workers per training device. Can exceed
+        n_workers; multiple DataLoader workers will share partitions.
     """
 
     def __init__(
@@ -81,6 +113,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         apply_ctf: bool = False,
         downsample: int = 1,
         pool_size: int = DEFAULT_POOL_SIZE,
+        dataloader_workers: int = 2,
     ):
         super().__init__()
         # data module controls
@@ -88,6 +121,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         self.epoch_size = steps_per_epoch * batch_size
         self.n_workers = n_workers
         self.pool_size = pool_size
+        self.dataloader_workers = dataloader_workers
 
         # Validate pool size
         self.partition_size = pool_size // n_workers
@@ -98,7 +132,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
                 f"2 * batch_size ({2 * batch_size}). Increase pool_size or "
                 f"decrease n_workers/batch_size."
             )
-        
+
         # This is an old code path that used cpu's for reconstruction
         # we have abandonded it in favor of splitting the GPU's
         if reconstruction_accelerators in [None, []]:
@@ -110,9 +144,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
             raise ValueError(
                 "Number of reconstruction accelerators must match n_workers"
             )
-        self.reconstruction_devices = [
-            f"cuda:{x}" for x in reconstruction_accelerators
-        ]
+        self.reconstruction_devices = [f"cuda:{x}" for x in reconstruction_accelerators]
 
         # reconstruction controls
         self.patch_size = patch_size
@@ -177,9 +209,13 @@ class MissAlignmentDataModule(pl.LightningDataModule):
             p.start()
             self.pool_processes.append(p)
 
-        # Create dataset
+        # Create dataset (global_rank is obtained in worker_init_fn
+        # from torch.distributed)
         self.train_dataset = ReconstructionPoolDataset(
-            self.pool_dir, self.batch_size, self.epoch_size
+            pool_dir=self.pool_dir,
+            batch_size=self.batch_size,
+            epoch_size=self.epoch_size,
+            n_partitions=self.n_workers,
         )
 
     def train_dataloader(self):
@@ -189,7 +225,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,  # data is already randomized by recon workers
             drop_last=True,
-            num_workers=self.n_workers,
+            num_workers=self.dataloader_workers,
             worker_init_fn=_worker_init_fn,
             multiprocessing_context="fork",
             persistent_workers=True,

--- a/src/miss_alignment/data/training_dataset.py
+++ b/src/miss_alignment/data/training_dataset.py
@@ -33,12 +33,21 @@ class ReconstructionPoolDataset(Dataset):
         Minimum number of files required before reading (pause threshold)
     epoch_size : int
         Number of samples per epoch
+    n_partitions : int
+        Total number of partitions (reconstruction workers)
     """
 
-    def __init__(self, pool_dir: Path, batch_size: int, epoch_size: int):
+    def __init__(
+        self,
+        pool_dir: Path,
+        batch_size: int,
+        epoch_size: int,
+        n_partitions: int,
+    ):
         self.pool_dir = pool_dir
         self.batch_size = batch_size
         self.epoch_size = epoch_size
+        self.n_partitions = n_partitions
         # partition_id is set by worker_init_fn in the DataLoader
         self.partition_id: int | None = None
 
@@ -54,10 +63,7 @@ class ReconstructionPoolDataset(Dataset):
             )
         pattern = f"partition_{self.partition_id}_*.pickle"
         # Filter out temp files (they start with tmp_)
-        return [
-            f for f in self.pool_dir.glob(pattern)
-            if not f.name.startswith("tmp_")
-        ]
+        return [f for f in self.pool_dir.glob(pattern) if not f.name.startswith("tmp_")]
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
         """
@@ -116,7 +122,8 @@ class ReconstructionPoolDataset(Dataset):
         volumes, labels = zip(*combined)
         labels = torch.tensor(labels)
 
-        # run normalization and augmentation (no mirroring - done by reconstruction worker)
+        # run normalization and augmentation (no mirroring -
+        # done by reconstruction worker)
         volumes = self._prep_and_augment(list(volumes))
         # add empty channel dim to all volumes
         volumes = [einops.rearrange(v, "d h w -> 1 d h w") for v in volumes]

--- a/src/miss_alignment/data/training_dataset.py
+++ b/src/miss_alignment/data/training_dataset.py
@@ -56,12 +56,16 @@ class ReconstructionPoolDataset(Dataset):
         return self.epoch_size
 
     def _list_partition_files(self) -> list[Path]:
-        """List all files in this worker's partition."""
+        """List all files in this worker's partition.
+
+        Files are named: partition_{partition_id}_worker_{worker_id}_seq_{seq_id}.pickle
+        Multiple reconstruction workers write to each partition.
+        """
         if self.partition_id is None:
             raise RuntimeError(
                 "partition_id not set. Ensure worker_init_fn assigns it."
             )
-        pattern = f"partition_{self.partition_id}_*.pickle"
+        pattern = f"partition_{self.partition_id}_worker_*_seq_*.pickle"
         # Filter out temp files (they start with tmp_)
         return [f for f in self.pool_dir.glob(pattern) if not f.name.startswith("tmp_")]
 

--- a/src/miss_alignment/models/_compact.py
+++ b/src/miss_alignment/models/_compact.py
@@ -37,16 +37,16 @@ class Compact3DConvNet(nn.Module):
 
         # Shared feature layer
         self.features = nn.Sequential(
-            nn.Linear(64, 32),
-            nn.LayerNorm(32),
+            nn.Linear(64, 16),
+            nn.LayerNorm(16),
             nn.SiLU(),
         )
 
         # Score head
-        self.score_head = nn.Linear(32, 1, bias=False)
+        self.score_head = nn.Linear(16, 1, bias=False)
 
         # Log-precision head for uncertainty estimation
-        self.log_precision_head = nn.Linear(32, 1)
+        self.log_precision_head = nn.Linear(16, 1)
 
     def forward(self, x):
         # Assuming input shape: (batch_size, 1, 64, 64, 64)

--- a/src/miss_alignment/models/_compact.py
+++ b/src/miss_alignment/models/_compact.py
@@ -37,22 +37,22 @@ class Compact3DConvNet(nn.Module):
 
         # Shared feature layer
         self.features = nn.Sequential(
-            nn.Linear(64, 16),
-            nn.BatchNorm1d(16),
+            nn.Linear(64, 32),
+            nn.BatchNorm1d(32),
             nn.SiLU(),
         )
 
         # Score head
-        self.score_head = nn.Linear(16, 1, bias=False)
+        self.score_head = nn.Linear(32, 1, bias=False)
 
         # Log-precision head for uncertainty estimation
-        self.log_precision_head = nn.Linear(16, 1)
+        self.log_precision_head = nn.Linear(32, 1)
 
     def forward(self, x):
         # Assuming input shape: (batch_size, 1, 64, 64, 64)
         x = self.conv(x)
         x = x.view(x.size(0), -1)  # Flatten: (batch_size, 64)
-        x = self.features(x)  # Shared features: (batch_size, 16)
+        x = self.features(x)  # Shared features: (batch_size, 32)
         score = self.score_head(x)  # (batch_size, 1)
         log_precision = self.log_precision_head(x)  # (batch_size, 1)
         return score, log_precision

--- a/src/miss_alignment/models/_compact.py
+++ b/src/miss_alignment/models/_compact.py
@@ -9,27 +9,27 @@ class Compact3DConvNet(nn.Module):
         self.conv = nn.Sequential(
             # Layer 0: 64x64x64 -> 64x64x64
             nn.Conv3d(1, 8, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.SiLU(),
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.SiLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.SiLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(32, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.SiLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.SiLU(),
             # Layer 5: 4x4x4 -> 2x2x2
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.SiLU(),
             # Global average pooling: 2x2x2 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -38,7 +38,7 @@ class Compact3DConvNet(nn.Module):
         # Shared feature layer
         self.features = nn.Sequential(
             nn.Linear(64, 32),
-            nn.BatchNorm1d(32),
+            nn.LayerNorm(32),
             nn.SiLU(),
         )
 
@@ -66,19 +66,19 @@ class Compact3DConvNetGELU(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.GELU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.GELU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.GELU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.GELU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -107,19 +107,19 @@ class Compact3DConvNetSpread(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=7, stride=2, padding=3),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.ReLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -148,19 +148,19 @@ class Compact3DConvNetWide(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(32, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.ReLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.ReLU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -188,31 +188,31 @@ class Compact3DConvNetDeep(nn.Module):
         self.conv = nn.Sequential(
             # Block 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.ReLU(),
             nn.Conv3d(8, 8, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.ReLU(),
             # Block 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             nn.Conv3d(16, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             # Block 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Block 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Global average pooling
             nn.AdaptiveAvgPool3d(1),
@@ -246,9 +246,13 @@ class Bottleneck3D(nn.Module):
         Stride for the 3x3x3 convolution (use 2 for downsampling)
     expansion : int, default=2
         Expansion factor for output channels
+    num_groups : int, default=8
+        Number of groups for GroupNorm
     """
 
-    def __init__(self, in_channels, bottleneck_channels, stride=1, expansion=2):
+    def __init__(
+        self, in_channels, bottleneck_channels, stride=1, expansion=2, num_groups=8
+    ):
         super().__init__()
 
         out_channels = bottleneck_channels * expansion
@@ -256,7 +260,7 @@ class Bottleneck3D(nn.Module):
         self.conv1 = nn.Conv3d(
             in_channels, bottleneck_channels, kernel_size=1, stride=1, bias=False
         )
-        self.bn1 = nn.BatchNorm3d(bottleneck_channels)
+        self.bn1 = nn.GroupNorm(num_groups, bottleneck_channels)
 
         self.conv2 = nn.Conv3d(
             bottleneck_channels,
@@ -266,12 +270,12 @@ class Bottleneck3D(nn.Module):
             padding=1,
             bias=False,
         )
-        self.bn2 = nn.BatchNorm3d(bottleneck_channels)
+        self.bn2 = nn.GroupNorm(num_groups, bottleneck_channels)
 
         self.conv3 = nn.Conv3d(
             bottleneck_channels, out_channels, kernel_size=1, stride=1, bias=False
         )
-        self.bn3 = nn.BatchNorm3d(out_channels)
+        self.bn3 = nn.GroupNorm(num_groups, out_channels)
 
         self.gelu = nn.GELU()
 
@@ -281,7 +285,7 @@ class Bottleneck3D(nn.Module):
                 nn.Conv3d(
                     in_channels, out_channels, kernel_size=1, stride=stride, bias=False
                 ),
-                nn.BatchNorm3d(out_channels),
+                nn.GroupNorm(num_groups, out_channels),
             )
 
     def forward(self, x):
@@ -320,9 +324,9 @@ class CompactResNet3D(nn.Module):
     def __init__(self):
         super().__init__()
 
-        # Initial convolution: 64^3 -> 64^3, 1 -> 24 channels
+        # Initial convolution: 64^3 -> 64^3, 1 -> 16 channels
         self.conv1 = nn.Conv3d(1, 16, kernel_size=3, stride=1, padding=1, bias=False)
-        self.bn1 = nn.BatchNorm3d(16)
+        self.bn1 = nn.GroupNorm(8, 16)
         self.gelu = nn.GELU()
 
         # Stage 1: 64^3 -> 32^3, 16 -> 16

--- a/src/miss_alignment/models/_compact.py
+++ b/src/miss_alignment/models/_compact.py
@@ -9,27 +9,27 @@ class Compact3DConvNet(nn.Module):
         self.conv = nn.Sequential(
             # Layer 0: 64x64x64 -> 64x64x64
             nn.Conv3d(1, 8, kernel_size=3, stride=1, padding=1),
-            nn.GroupNorm(8, 8),
+            nn.BatchNorm3d(8),
             nn.SiLU(),
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 16),
+            nn.BatchNorm3d(16),
             nn.SiLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.SiLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(32, 64, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 64),
+            nn.BatchNorm3d(64),
             nn.SiLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 64),
+            nn.BatchNorm3d(64),
             nn.SiLU(),
             # Layer 5: 4x4x4 -> 2x2x2
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 64),
+            nn.BatchNorm3d(64),
             nn.SiLU(),
             # Global average pooling: 2x2x2 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -66,19 +66,19 @@ class Compact3DConvNetGELU(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 8),
+            nn.BatchNorm3d(8),
             nn.GELU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 16),
+            nn.BatchNorm3d(16),
             nn.GELU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.GELU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.GELU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -107,19 +107,19 @@ class Compact3DConvNetSpread(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=7, stride=2, padding=3),
-            nn.GroupNorm(8, 8),
+            nn.BatchNorm3d(8),
             nn.ReLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 16),
+            nn.BatchNorm3d(16),
             nn.ReLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -148,19 +148,19 @@ class Compact3DConvNetWide(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 16, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 16),
+            nn.BatchNorm3d(16),
             nn.ReLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(32, 64, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 64),
+            nn.BatchNorm3d(64),
             nn.ReLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 64),
+            nn.BatchNorm3d(64),
             nn.ReLU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -188,31 +188,31 @@ class Compact3DConvNetDeep(nn.Module):
         self.conv = nn.Sequential(
             # Block 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=3, stride=1, padding=1),
-            nn.GroupNorm(8, 8),
+            nn.BatchNorm3d(8),
             nn.ReLU(),
             nn.Conv3d(8, 8, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 8),
+            nn.BatchNorm3d(8),
             nn.ReLU(),
             # Block 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=1, padding=1),
-            nn.GroupNorm(8, 16),
+            nn.BatchNorm3d(16),
             nn.ReLU(),
             nn.Conv3d(16, 16, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 16),
+            nn.BatchNorm3d(16),
             nn.ReLU(),
             # Block 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=1, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             # Block 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=1, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.GroupNorm(8, 32),
+            nn.BatchNorm3d(32),
             nn.ReLU(),
             # Global average pooling
             nn.AdaptiveAvgPool3d(1),
@@ -246,13 +246,9 @@ class Bottleneck3D(nn.Module):
         Stride for the 3x3x3 convolution (use 2 for downsampling)
     expansion : int, default=2
         Expansion factor for output channels
-    num_groups : int, default=8
-        Number of groups for GroupNorm
     """
 
-    def __init__(
-        self, in_channels, bottleneck_channels, stride=1, expansion=2, num_groups=8
-    ):
+    def __init__(self, in_channels, bottleneck_channels, stride=1, expansion=2):
         super().__init__()
 
         out_channels = bottleneck_channels * expansion
@@ -260,7 +256,7 @@ class Bottleneck3D(nn.Module):
         self.conv1 = nn.Conv3d(
             in_channels, bottleneck_channels, kernel_size=1, stride=1, bias=False
         )
-        self.bn1 = nn.GroupNorm(num_groups, bottleneck_channels)
+        self.bn1 = nn.BatchNorm3d(bottleneck_channels)
 
         self.conv2 = nn.Conv3d(
             bottleneck_channels,
@@ -270,12 +266,12 @@ class Bottleneck3D(nn.Module):
             padding=1,
             bias=False,
         )
-        self.bn2 = nn.GroupNorm(num_groups, bottleneck_channels)
+        self.bn2 = nn.BatchNorm3d(bottleneck_channels)
 
         self.conv3 = nn.Conv3d(
             bottleneck_channels, out_channels, kernel_size=1, stride=1, bias=False
         )
-        self.bn3 = nn.GroupNorm(num_groups, out_channels)
+        self.bn3 = nn.BatchNorm3d(out_channels)
 
         self.gelu = nn.GELU()
 
@@ -285,7 +281,7 @@ class Bottleneck3D(nn.Module):
                 nn.Conv3d(
                     in_channels, out_channels, kernel_size=1, stride=stride, bias=False
                 ),
-                nn.GroupNorm(num_groups, out_channels),
+                nn.BatchNorm3d(out_channels),
             )
 
     def forward(self, x):
@@ -326,7 +322,7 @@ class CompactResNet3D(nn.Module):
 
         # Initial convolution: 64^3 -> 64^3, 1 -> 16 channels
         self.conv1 = nn.Conv3d(1, 16, kernel_size=3, stride=1, padding=1, bias=False)
-        self.bn1 = nn.GroupNorm(8, 16)
+        self.bn1 = nn.BatchNorm3d(16)
         self.gelu = nn.GELU()
 
         # Stage 1: 64^3 -> 32^3, 16 -> 16

--- a/src/miss_alignment/models/_compact.py
+++ b/src/miss_alignment/models/_compact.py
@@ -38,7 +38,7 @@ class Compact3DConvNet(nn.Module):
         # Shared feature layer
         self.features = nn.Sequential(
             nn.Linear(64, 16),
-            nn.LayerNorm(16),
+            nn.BatchNorm1d(16),
             nn.SiLU(),
         )
 

--- a/src/miss_alignment/models/_compact.py
+++ b/src/miss_alignment/models/_compact.py
@@ -9,27 +9,27 @@ class Compact3DConvNet(nn.Module):
         self.conv = nn.Sequential(
             # Layer 0: 64x64x64 -> 64x64x64
             nn.Conv3d(1, 8, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.SiLU(),
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.SiLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.SiLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(32, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.SiLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.SiLU(),
             # Layer 5: 4x4x4 -> 2x2x2
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.SiLU(),
             # Global average pooling: 2x2x2 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -38,7 +38,7 @@ class Compact3DConvNet(nn.Module):
         # Shared feature layer
         self.features = nn.Sequential(
             nn.Linear(64, 16),
-            nn.BatchNorm1d(16),
+            nn.LayerNorm(16),
             nn.SiLU(),
         )
 
@@ -66,19 +66,19 @@ class Compact3DConvNetGELU(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.GELU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.GELU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.GELU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.GELU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -107,19 +107,19 @@ class Compact3DConvNetSpread(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=7, stride=2, padding=3),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.ReLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -148,19 +148,19 @@ class Compact3DConvNetWide(nn.Module):
         self.conv = nn.Sequential(
             # Layer 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             # Layer 2: 32x32x32 -> 16x16x16
             nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Layer 3: 16x16x16 -> 8x8x8
             nn.Conv3d(32, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.ReLU(),
             # Layer 4: 8x8x8 -> 4x4x4
             nn.Conv3d(64, 64, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(64),
+            nn.GroupNorm(8, 64),
             nn.ReLU(),
             # Global average pooling: 4x4x4 -> 1x1x1
             nn.AdaptiveAvgPool3d(1),
@@ -188,31 +188,31 @@ class Compact3DConvNetDeep(nn.Module):
         self.conv = nn.Sequential(
             # Block 1: 64x64x64 -> 32x32x32
             nn.Conv3d(1, 8, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.ReLU(),
             nn.Conv3d(8, 8, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(8),
+            nn.GroupNorm(8, 8),
             nn.ReLU(),
             # Block 2: 32x32x32 -> 16x16x16
             nn.Conv3d(8, 16, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             nn.Conv3d(16, 16, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(16),
+            nn.GroupNorm(8, 16),
             nn.ReLU(),
             # Block 3: 16x16x16 -> 8x8x8
             nn.Conv3d(16, 32, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Block 4: 8x8x8 -> 4x4x4
             nn.Conv3d(32, 32, kernel_size=3, stride=1, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             nn.Conv3d(32, 32, kernel_size=3, stride=2, padding=1),
-            nn.BatchNorm3d(32),
+            nn.GroupNorm(8, 32),
             nn.ReLU(),
             # Global average pooling
             nn.AdaptiveAvgPool3d(1),
@@ -256,7 +256,7 @@ class Bottleneck3D(nn.Module):
         self.conv1 = nn.Conv3d(
             in_channels, bottleneck_channels, kernel_size=1, stride=1, bias=False
         )
-        self.bn1 = nn.BatchNorm3d(bottleneck_channels)
+        self.bn1 = nn.GroupNorm(8, bottleneck_channels)
 
         self.conv2 = nn.Conv3d(
             bottleneck_channels,
@@ -266,12 +266,12 @@ class Bottleneck3D(nn.Module):
             padding=1,
             bias=False,
         )
-        self.bn2 = nn.BatchNorm3d(bottleneck_channels)
+        self.bn2 = nn.GroupNorm(8, bottleneck_channels)
 
         self.conv3 = nn.Conv3d(
             bottleneck_channels, out_channels, kernel_size=1, stride=1, bias=False
         )
-        self.bn3 = nn.BatchNorm3d(out_channels)
+        self.bn3 = nn.GroupNorm(8, out_channels)
 
         self.gelu = nn.GELU()
 
@@ -281,7 +281,7 @@ class Bottleneck3D(nn.Module):
                 nn.Conv3d(
                     in_channels, out_channels, kernel_size=1, stride=stride, bias=False
                 ),
-                nn.BatchNorm3d(out_channels),
+                nn.GroupNorm(8, out_channels),
             )
 
     def forward(self, x):
@@ -322,7 +322,7 @@ class CompactResNet3D(nn.Module):
 
         # Initial convolution: 64^3 -> 64^3, 1 -> 16 channels
         self.conv1 = nn.Conv3d(1, 16, kernel_size=3, stride=1, padding=1, bias=False)
-        self.bn1 = nn.BatchNorm3d(16)
+        self.bn1 = nn.GroupNorm(8, 16)
         self.gelu = nn.GELU()
 
         # Stage 1: 64^3 -> 32^3, 16 -> 16

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -169,6 +169,17 @@ class MissAlignment(pl.LightningModule):
         score2, log_prec2 = self(img2)
         score3, log_prec3 = self(img3)
 
+        # DEBUG: Check for model collapse (all zeros or NaN)
+        if self.current_epoch >= 2:
+            scores_raw = torch.stack([score1, score2, score3])
+            log_prec_raw = torch.stack([log_prec1, log_prec2, log_prec3])
+            print(f"  [RAW] scores: {scores_raw.flatten()[:6].tolist()}")
+            print(f"  [RAW] log_prec: {log_prec_raw.flatten()[:6].tolist()}")
+            if (scores_raw == 0).all():
+                print("  [WARN] All scores are exactly zero!")
+            if torch.isnan(scores_raw).any():
+                print("  [WARN] NaN detected in scores!")
+
         # Stack into (batch, 3) format
         scores = torch.stack((score1, score2, score3), dim=1)
         scores = einops.rearrange(scores, "b d 1 -> b d")

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -344,6 +344,12 @@ class MissAlignment(pl.LightningModule):
 
         return [optimizer], [scheduler]
 
+    def configure_model(self):
+        """Configure model with torch.compile for faster training."""
+        # Only compile if not already compiled
+        if not isinstance(self.net, torch._dynamo.eval_frame.OptimizedModule):
+            self.net = torch.compile(self.net)
+
 
 class MAProgressBar(Callback):
     """Progress bar showing progress across the entire macro-iteration.

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -493,40 +493,31 @@ class MAEarlyStopping(Callback):
     def on_train_epoch_end(self, trainer, pl_module):
         """Called at the end of each training epoch.
 
-        Only rank 0 evaluates early stopping logic. The decision is then
-        broadcast to all ranks to ensure synchronized stopping.
+        All ranks evaluate stopping logic (metrics are synced via sync_dist=True),
+        then the decision is synchronized using Lightning's reduce_boolean_decision.
+        This mirrors PyTorch Lightning's built-in EarlyStopping approach.
         """
+        # Check if we should start early stopping yet
+        if not self._check_scheduler_complete(trainer, pl_module):
+            return
+
+        # Get the monitored metric (synced across ranks via sync_dist=True)
+        logged_metrics = trainer.callback_metrics
+        if "train_loss" not in logged_metrics:
+            return  # Metric not available yet
+
+        current_score = float(logged_metrics["train_loss"])
+
+        # Evaluate stopping criteria (all ranks do this)
         should_stop = False
-
-        # Only rank 0 evaluates early stopping
-        if trainer.global_rank == 0:
-            # Check if we should start early stopping yet
-            if self._check_scheduler_complete(trainer, pl_module):
-                logged_metrics = trainer.logged_metrics
-
-                if "train_loss" not in logged_metrics:
-                    raise ValueError("Couldn't find train_loss in logged_metrics")
-
-                current_score = float(logged_metrics["train_loss"])
-
-                if (
-                    self.best_score is None
-                    or current_score < self.best_score - self.min_delta
-                ):
-                    self.best_score = current_score
-                    self.wait_count = 0
-                else:
-                    self.wait_count += 1
-
-                if self.wait_count >= self.patience:
-                    should_stop = True
-
-        # Sync across all ranks using all_reduce (all ranks participate equally)
-        if torch.distributed.is_initialized():
-            stop_tensor = torch.tensor(
-                [1 if should_stop else 0], device=pl_module.device, dtype=torch.int
-            )
-            torch.distributed.all_reduce(stop_tensor, op=torch.distributed.ReduceOp.MAX)
-            trainer.should_stop = stop_tensor.item() > 0
+        if self.best_score is None or current_score < self.best_score - self.min_delta:
+            self.best_score = current_score
+            self.wait_count = 0
         else:
-            trainer.should_stop = should_stop
+            self.wait_count += 1
+            if self.wait_count >= self.patience:
+                should_stop = True
+
+        # Sync decision across all ranks (stop if ANY rank decides to stop)
+        should_stop = trainer.strategy.reduce_boolean_decision(should_stop, all=False)
+        trainer.should_stop = trainer.should_stop or should_stop

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -489,26 +489,35 @@ class MAEarlyStopping(Callback):
     def on_train_epoch_end(self, trainer, pl_module):
         """Called at the end of each training epoch."""
         # Only evaluate early stopping on rank 0 to ensure consistent decisions.
-        # Lightning will synchronize trainer.should_stop across all ranks.
-        if trainer.global_rank != 0:
-            return
+        # We must manually broadcast should_stop to all ranks after.
+        if trainer.global_rank == 0:
+            # Check if we should start early stopping yet
+            if self._check_scheduler_complete(trainer, pl_module):
+                logged_metrics = trainer.logged_metrics
 
-        # Check if we should start early stopping yet
-        if not self._check_scheduler_complete(trainer, pl_module):
-            return
+                if "train_loss" in logged_metrics:
+                    current_score = logged_metrics["train_loss"]
+                else:
+                    raise ValueError("Couldn't find train_loss in pl_module")
 
-        logged_metrics = trainer.logged_metrics
+                if (
+                    self.best_score is None
+                    or current_score < self.best_score - self.min_delta
+                ):
+                    self.best_score = current_score
+                    self.wait_count = 0
+                else:
+                    self.wait_count += 1
 
-        if "train_loss" in logged_metrics:
-            current_score = logged_metrics["train_loss"]
-        else:
-            raise ValueError("Couldn't find train_loss in pl_module")
+                if self.wait_count >= self.patience:
+                    trainer.should_stop = True
 
-        if self.best_score is None or current_score < self.best_score - self.min_delta:
-            self.best_score = current_score
-            self.wait_count = 0
-        else:
-            self.wait_count += 1
-
-        if self.wait_count >= self.patience:
-            trainer.should_stop = True
+        # Synchronize should_stop across all ranks to prevent NCCL deadlock.
+        # Without this, rank 0 may stop while other ranks continue, causing
+        # them to diverge in their collective operations.
+        if torch.distributed.is_initialized():
+            should_stop_tensor = torch.tensor(
+                [trainer.should_stop], dtype=torch.int, device=pl_module.device
+            )
+            torch.distributed.broadcast(should_stop_tensor, src=0)
+            trainer.should_stop = bool(should_stop_tensor.item())

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -390,12 +390,6 @@ class MAProgressBar(Callback):
 
         from tqdm import tqdm
 
-        # Adjust total_steps for DDP world size, since DistributedSampler
-        # divides the data among GPUs
-        world_size = trainer.world_size
-        steps_per_epoch_per_rank = self.steps_per_epoch // world_size
-        self.total_steps = self.max_epochs * steps_per_epoch_per_rank
-
         self.start_time = time.time()
         self.pbar = tqdm(
             total=self.total_steps,

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -487,18 +487,24 @@ class MAEarlyStopping(Callback):
         return False
 
     def on_train_epoch_end(self, trainer, pl_module):
-        """Called at the end of each training epoch."""
-        # Only evaluate early stopping on rank 0 to ensure consistent decisions.
-        # We must manually broadcast should_stop to all ranks after.
+        """Called at the end of each training epoch.
+
+        Only rank 0 evaluates early stopping logic. The decision is then
+        synchronized using Lightning's strategy.reduce_boolean_decision,
+        which is designed to work with Lightning's internal DDP operations.
+        """
+        should_stop = False
+
+        # Only rank 0 evaluates early stopping
         if trainer.global_rank == 0:
             # Check if we should start early stopping yet
             if self._check_scheduler_complete(trainer, pl_module):
                 logged_metrics = trainer.logged_metrics
 
-                if "train_loss" in logged_metrics:
-                    current_score = logged_metrics["train_loss"]
-                else:
-                    raise ValueError("Couldn't find train_loss in pl_module")
+                if "train_loss" not in logged_metrics:
+                    raise ValueError("Couldn't find train_loss in logged_metrics")
+
+                current_score = float(logged_metrics["train_loss"])
 
                 if (
                     self.best_score is None
@@ -510,14 +516,10 @@ class MAEarlyStopping(Callback):
                     self.wait_count += 1
 
                 if self.wait_count >= self.patience:
-                    trainer.should_stop = True
+                    should_stop = True
 
-        # Synchronize should_stop across all ranks to prevent NCCL deadlock.
-        # Without this, rank 0 may stop while other ranks continue, causing
-        # them to diverge in their collective operations.
-        if torch.distributed.is_initialized():
-            should_stop_tensor = torch.tensor(
-                [trainer.should_stop], dtype=torch.int, device=pl_module.device
-            )
-            torch.distributed.broadcast(should_stop_tensor, src=0)
-            trainer.should_stop = bool(should_stop_tensor.item())
+        # Use Lightning's strategy to sync the decision across ranks.
+        # This is the Lightning-approved way to broadcast boolean decisions
+        # and avoids conflicts with internal DDP operations.
+        should_stop = trainer.strategy.reduce_boolean_decision(should_stop, all=False)
+        trainer.should_stop = should_stop

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -521,8 +521,12 @@ class MAEarlyStopping(Callback):
                 if self.wait_count >= self.patience:
                     should_stop = True
 
-        # Broadcast rank 0's decision to all ranks using a tensor
-        device = pl_module.device
-        stop_tensor = torch.tensor([should_stop], dtype=torch.int, device=device)
-        torch.distributed.broadcast(stop_tensor, src=0)
-        trainer.should_stop = bool(stop_tensor.item())
+        # Sync all ranks before broadcasting
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+            device = pl_module.device
+            stop_tensor = torch.tensor([should_stop], dtype=torch.int, device=device)
+            torch.distributed.broadcast(stop_tensor, src=0)
+            trainer.should_stop = bool(stop_tensor.item())
+        else:
+            trainer.should_stop = should_stop

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -371,6 +371,7 @@ class MAProgressBar(Callback):
         self.max_epochs = max_epochs
         self.steps_per_epoch = steps_per_epoch
         self.refresh_rate = refresh_rate
+        # total_steps will be adjusted for world_size in on_train_start
         self.total_steps = max_epochs * steps_per_epoch
         self.pbar = None
         self.start_time = None
@@ -389,6 +390,12 @@ class MAProgressBar(Callback):
 
         from tqdm import tqdm
 
+        # Adjust total_steps for DDP world size, since DistributedSampler
+        # divides the data among GPUs
+        world_size = trainer.world_size
+        steps_per_epoch_per_rank = self.steps_per_epoch // world_size
+        self.total_steps = self.max_epochs * steps_per_epoch_per_rank
+
         self.start_time = time.time()
         self.pbar = tqdm(
             total=self.total_steps,
@@ -404,7 +411,9 @@ class MAProgressBar(Callback):
         if not self._is_rank_zero(trainer) or self.pbar is None:
             return
 
-        global_step = trainer.current_epoch * self.steps_per_epoch + batch_idx + 1
+        # Use trainer.global_step which correctly tracks optimizer steps
+        # regardless of DDP world size
+        global_step = trainer.global_step
 
         if global_step % self.refresh_rate == 0 or global_step == self.total_steps:
             # Update progress bar to current position

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -390,6 +390,10 @@ class MAProgressBar(Callback):
 
         from tqdm import tqdm
 
+        # Adjust total_steps for distributed training
+        world_size = trainer.world_size
+        self.total_steps = self.total_steps // world_size
+
         self.start_time = time.time()
         self.pbar = tqdm(
             total=self.total_steps,

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -212,6 +212,33 @@ class MissAlignment(pl.LightningModule):
             mean_precision,
         ) = self._common_step(batch, batch_idx)
 
+        # DEBUG: Print diagnostics at start of each epoch (first batch)
+        if batch_idx == 0 and self.global_rank == 0:
+            # Check input data statistics
+            img1, img2, img3, target = batch
+            print(f"\n[DEBUG] Epoch {self.current_epoch}, Step {self.global_step}")
+            print(
+                f"  img1: mean={img1.mean():.4f}, std={img1.std():.4f}, "
+                f"min={img1.min():.4f}, max={img1.max():.4f}"
+            )
+            print(f"  img2: mean={img2.mean():.4f}, std={img2.std():.4f}")
+            print(f"  img3: mean={img3.mean():.4f}, std={img3.std():.4f}")
+            print(
+                f"  Loss: {total_loss.item():.6f} "
+                f"(triplet: {triplet_loss.item():.6f}, "
+                f"prec_reg: {precision_reg.item():.6f})"
+            )
+            score_diff = score_aligned.item() - score_misaligned.item()
+            print(
+                f"  Scores: aligned={score_aligned.item():.6f}, "
+                f"misaligned={score_misaligned.item():.6f}, diff={score_diff:.6f}"
+            )
+            print(f"  Mean precision: {mean_precision.item():.6f}")
+
+            # Get current learning rate
+            lr = self.optimizers().param_groups[0]["lr"]
+            print(f"  Learning rate: {lr:.2e}")
+
         # Fail fast on NaN loss to prevent corrupted training
         if torch.isnan(total_loss):
             raise ValueError(
@@ -306,6 +333,30 @@ class MissAlignment(pl.LightningModule):
 
     def predict_step(self):
         pass
+
+    def on_train_epoch_end(self):
+        """DEBUG: Print gradient and weight statistics at end of each epoch."""
+        if self.global_rank == 0:
+            grad_norm = 0.0
+            param_norm = 0.0
+            num_zero_grad = 0
+            num_params = 0
+            for name, p in self.named_parameters():
+                num_params += 1
+                param_norm += p.data.norm(2).item() ** 2
+                if p.grad is not None:
+                    g_norm = p.grad.data.norm(2).item()
+                    grad_norm += g_norm**2
+                    if g_norm < 1e-10:
+                        num_zero_grad += 1
+                else:
+                    num_zero_grad += 1
+            grad_norm = grad_norm**0.5
+            param_norm = param_norm**0.5
+
+            print(f"[DEBUG] End of Epoch {self.current_epoch}")
+            print(f"  Grad norm: {grad_norm:.6f}, Param norm: {param_norm:.6f}")
+            print(f"  Params with zero/no grad: {num_zero_grad}/{num_params}")
 
     def configure_optimizers(self):
         """Configure optimizer and learning rate schedulers.

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -521,6 +521,12 @@ class MAEarlyStopping(Callback):
                 if self.wait_count >= self.patience:
                     should_stop = True
 
-        # Just set on rank 0 - Lightning should sync this internally
-        if trainer.global_rank == 0:
+        # Sync across all ranks using all_reduce (all ranks participate equally)
+        if torch.distributed.is_initialized():
+            stop_tensor = torch.tensor(
+                [1 if should_stop else 0], device=pl_module.device, dtype=torch.int
+            )
+            torch.distributed.all_reduce(stop_tensor, op=torch.distributed.ReduceOp.MAX)
+            trainer.should_stop = stop_tensor.item() > 0
+        else:
             trainer.should_stop = should_stop

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -521,12 +521,6 @@ class MAEarlyStopping(Callback):
                 if self.wait_count >= self.patience:
                     should_stop = True
 
-        # Sync all ranks before broadcasting
-        if torch.distributed.is_initialized():
-            torch.distributed.barrier()
-            device = pl_module.device
-            stop_tensor = torch.tensor([should_stop], dtype=torch.int, device=device)
-            torch.distributed.broadcast(stop_tensor, src=0)
-            trainer.should_stop = bool(stop_tensor.item())
-        else:
+        # Just set on rank 0 - Lightning should sync this internally
+        if trainer.global_rank == 0:
             trainer.should_stop = should_stop

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -169,17 +169,6 @@ class MissAlignment(pl.LightningModule):
         score2, log_prec2 = self(img2)
         score3, log_prec3 = self(img3)
 
-        # DEBUG: Check for model collapse (all zeros or NaN)
-        if self.current_epoch >= 2:
-            scores_raw = torch.stack([score1, score2, score3])
-            log_prec_raw = torch.stack([log_prec1, log_prec2, log_prec3])
-            print(f"  [RAW] scores: {scores_raw.flatten()[:6].tolist()}")
-            print(f"  [RAW] log_prec: {log_prec_raw.flatten()[:6].tolist()}")
-            if (scores_raw == 0).all():
-                print("  [WARN] All scores are exactly zero!")
-            if torch.isnan(scores_raw).any():
-                print("  [WARN] NaN detected in scores!")
-
         # Stack into (batch, 3) format
         scores = torch.stack((score1, score2, score3), dim=1)
         scores = einops.rearrange(scores, "b d 1 -> b d")
@@ -222,33 +211,6 @@ class MissAlignment(pl.LightningModule):
             score_misaligned,
             mean_precision,
         ) = self._common_step(batch, batch_idx)
-
-        # DEBUG: Print diagnostics at start of each epoch (first batch)
-        if batch_idx == 0 and self.global_rank == 0:
-            # Check input data statistics
-            img1, img2, img3, target = batch
-            print(f"\n[DEBUG] Epoch {self.current_epoch}, Step {self.global_step}")
-            print(
-                f"  img1: mean={img1.mean():.4f}, std={img1.std():.4f}, "
-                f"min={img1.min():.4f}, max={img1.max():.4f}"
-            )
-            print(f"  img2: mean={img2.mean():.4f}, std={img2.std():.4f}")
-            print(f"  img3: mean={img3.mean():.4f}, std={img3.std():.4f}")
-            print(
-                f"  Loss: {total_loss.item():.6f} "
-                f"(triplet: {triplet_loss.item():.6f}, "
-                f"prec_reg: {precision_reg.item():.6f})"
-            )
-            score_diff = score_aligned.item() - score_misaligned.item()
-            print(
-                f"  Scores: aligned={score_aligned.item():.6f}, "
-                f"misaligned={score_misaligned.item():.6f}, diff={score_diff:.6f}"
-            )
-            print(f"  Mean precision: {mean_precision.item():.6f}")
-
-            # Get current learning rate
-            lr = self.optimizers().param_groups[0]["lr"]
-            print(f"  Learning rate: {lr:.2e}")
 
         # Fail fast on NaN loss to prevent corrupted training
         if torch.isnan(total_loss):
@@ -344,30 +306,6 @@ class MissAlignment(pl.LightningModule):
 
     def predict_step(self):
         pass
-
-    def on_train_epoch_end(self):
-        """DEBUG: Print gradient and weight statistics at end of each epoch."""
-        if self.global_rank == 0:
-            grad_norm = 0.0
-            param_norm = 0.0
-            num_zero_grad = 0
-            num_params = 0
-            for name, p in self.named_parameters():
-                num_params += 1
-                param_norm += p.data.norm(2).item() ** 2
-                if p.grad is not None:
-                    g_norm = p.grad.data.norm(2).item()
-                    grad_norm += g_norm**2
-                    if g_norm < 1e-10:
-                        num_zero_grad += 1
-                else:
-                    num_zero_grad += 1
-            grad_norm = grad_norm**0.5
-            param_norm = param_norm**0.5
-
-            print(f"[DEBUG] End of Epoch {self.current_epoch}")
-            print(f"  Grad norm: {grad_norm:.6f}, Param norm: {param_norm:.6f}")
-            print(f"  Params with zero/no grad: {num_zero_grad}/{num_params}")
 
     def configure_optimizers(self):
         """Configure optimizer and learning rate schedulers.
@@ -556,8 +494,7 @@ class MAEarlyStopping(Callback):
         """Called at the end of each training epoch.
 
         Only rank 0 evaluates early stopping logic. The decision is then
-        synchronized using Lightning's strategy.reduce_boolean_decision,
-        which is designed to work with Lightning's internal DDP operations.
+        broadcast to all ranks to ensure synchronized stopping.
         """
         should_stop = False
 
@@ -584,8 +521,6 @@ class MAEarlyStopping(Callback):
                 if self.wait_count >= self.patience:
                     should_stop = True
 
-        # Use Lightning's strategy to sync the decision across ranks.
-        # This is the Lightning-approved way to broadcast boolean decisions
-        # and avoids conflicts with internal DDP operations.
-        should_stop = trainer.strategy.reduce_boolean_decision(should_stop, all=False)
+        # Broadcast rank 0's decision to all ranks
+        should_stop = trainer.strategy.broadcast(should_stop, src=0)
         trainer.should_stop = should_stop

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -227,6 +227,7 @@ class MissAlignment(pl.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
         self.log(
@@ -236,6 +237,7 @@ class MissAlignment(pl.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
         self.log(
@@ -245,6 +247,7 @@ class MissAlignment(pl.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
         # log actual assigned score of the model
@@ -255,6 +258,7 @@ class MissAlignment(pl.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
         self.log(
             name="train_score_misaligned",
@@ -263,6 +267,7 @@ class MissAlignment(pl.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
         # Log mean precision to monitor uncertainty learning
@@ -273,6 +278,7 @@ class MissAlignment(pl.LightningModule):
             on_step=False,
             on_epoch=True,
             logger=True,
+            sync_dist=True,
         )
 
         # Log the learning rate
@@ -369,7 +375,15 @@ class MAProgressBar(Callback):
         self.pbar = None
         self.start_time = None
 
+    def _is_rank_zero(self, trainer) -> bool:
+        """Check if we're on the main process (rank 0)."""
+        return trainer.global_rank == 0
+
     def on_train_start(self, trainer, pl_module):
+        # Only create progress bar on rank 0
+        if not self._is_rank_zero(trainer):
+            return
+
         import sys
         import time
 
@@ -386,6 +400,10 @@ class MAProgressBar(Callback):
         )
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        # Only update progress bar on rank 0
+        if not self._is_rank_zero(trainer) or self.pbar is None:
+            return
+
         global_step = trainer.current_epoch * self.steps_per_epoch + batch_idx + 1
 
         if global_step % self.refresh_rate == 0 or global_step == self.total_steps:
@@ -394,6 +412,10 @@ class MAProgressBar(Callback):
             self.pbar.refresh()
 
     def on_train_epoch_end(self, trainer, pl_module):
+        # Only update progress bar on rank 0
+        if not self._is_rank_zero(trainer) or self.pbar is None:
+            return
+
         # Update postfix with epoch metrics
         metrics = trainer.logged_metrics
         postfix = {}
@@ -411,7 +433,8 @@ class MAProgressBar(Callback):
             self.pbar.set_postfix(postfix)
 
     def on_train_end(self, trainer, pl_module):
-        if self.pbar is not None:
+        # Only close progress bar on rank 0
+        if self._is_rank_zero(trainer) and self.pbar is not None:
             self.pbar.close()
 
 
@@ -461,7 +484,12 @@ class MAEarlyStopping(Callback):
         return False
 
     def on_train_epoch_end(self, trainer, pl_module):
-        """Called at the end of each training batch."""
+        """Called at the end of each training epoch."""
+        # Only evaluate early stopping on rank 0 to ensure consistent decisions.
+        # Lightning will synchronize trainer.should_stop across all ranks.
+        if trainer.global_rank != 0:
+            return
+
         # Check if we should start early stopping yet
         if not self._check_scheduler_complete(trainer, pl_module):
             return

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -521,6 +521,8 @@ class MAEarlyStopping(Callback):
                 if self.wait_count >= self.patience:
                     should_stop = True
 
-        # Broadcast rank 0's decision to all ranks
-        should_stop = trainer.strategy.broadcast(should_stop, src=0)
-        trainer.should_stop = should_stop
+        # Broadcast rank 0's decision to all ranks using a tensor
+        device = pl_module.device
+        stop_tensor = torch.tensor([should_stop], dtype=torch.int, device=device)
+        torch.distributed.broadcast(stop_tensor, src=0)
+        trainer.should_stop = bool(stop_tensor.item())

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -344,12 +344,6 @@ class MissAlignment(pl.LightningModule):
 
         return [optimizer], [scheduler]
 
-    def configure_model(self):
-        """Configure model with torch.compile for faster training."""
-        # Only compile if not already compiled
-        if not isinstance(self.net, torch._dynamo.eval_frame.OptimizedModule):
-            self.net = torch.compile(self.net)
-
 
 class MAProgressBar(Callback):
     """Progress bar showing progress across the entire macro-iteration.

--- a/src/miss_alignment/prepare_stacks.py
+++ b/src/miss_alignment/prepare_stacks.py
@@ -4,6 +4,7 @@ This module provides functionality to load raw tilt images and create
 preprocessed tilt stacks ready for training.
 """
 
+import multiprocessing as mp
 import sys
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -89,7 +90,7 @@ def _prepare_single_tilt_series(
 
     ts = TiltSeries(xml_path)
     original_pixel_size = _get_original_pixel_size(ts)
-    #print(f"{xml_path.stem}: original pixel size = {original_pixel_size:.4f} Å")
+    # print(f"{xml_path.stem}: original pixel size = {original_pixel_size:.4f} Å")
 
     images, _, _ = ts.load_images(
         original_pixel_size=original_pixel_size,
@@ -145,7 +146,9 @@ def prepare_stacks_parallel(
         f"Preparing stacks for {len(xml_files)} tilt series at {desired_pixel_size} Å"
     )
 
-    with ProcessPoolExecutor(max_workers=n_processes) as executor:
+    # Use explicit spawn context to avoid CUDA issues with fork
+    ctx = mp.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=n_processes, mp_context=ctx) as executor:
         # Submit all tasks with round-robin device assignment
         futures = []
         for i, xml_path in enumerate(xml_files):
@@ -155,7 +158,9 @@ def prepare_stacks_parallel(
             )
             futures.append(future)
 
-        for future in tqdm(futures, desc="Preparing stacks", unit="tilt series", file=sys.stdout):
+        for future in tqdm(
+            futures, desc="Preparing stacks", unit="tilt series", file=sys.stdout
+        ):
             # This will raise any exception that occurred in the worker
             future.result()
 

--- a/src/miss_alignment/preprocessing.py
+++ b/src/miss_alignment/preprocessing.py
@@ -57,11 +57,12 @@ def run_cross_correlation_alignment(
 
         # Run cross-correlation alignment with pretilt estimation
         shifts, pretilt = tiltxcorr_with_sample_tilt_estimation(
-            stack.to(f"cuda:{device}"),
-            ts.angles.to(f"cuda:{device}"),
-            tilt_axis_angle,
-            lowpass_cutoff,
-            pretilt_search_range,
+            tilt_series=stack.to(f"cuda:{device}"),
+            tilt_angles=ts.angles.to(f"cuda:{device}"),
+            tilt_axis_angle=tilt_axis_angle,
+            pixel_spacing_angstroms=pixel_size,
+            lowpass_angstroms=pixel_size / lowpass_cutoff,
+            sample_tilt_range=pretilt_search_range,
         )
 
         # Convert shifts from pixels to Angstroms

--- a/src/miss_alignment/preprocessing.py
+++ b/src/miss_alignment/preprocessing.py
@@ -1,31 +1,105 @@
 """Preprocessing utilities for tilt-series alignment."""
 
+import multiprocessing as mp
+import sys
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
-from torch_tiltxcorr import tiltxcorr_with_sample_tilt_estimation
+from tqdm import tqdm
 
 from .data.io import TiltSeriesData
 
 
-def run_cross_correlation_alignment(
+def _run_cross_correlation_single(
+    xml_file: Path,
+    device: int | None,
+    lowpass_cutoff: float,
+    pretilt_search_range: tuple[float, float],
+) -> float:
+    """Run cross-correlation alignment on a single tilt-series.
+
+    Parameters
+    ----------
+    xml_file : Path
+        Path to the XML metadata file for the tilt-series.
+    device : int | None
+        CUDA device index to use. If None, uses default device.
+    lowpass_cutoff : float
+        Low-pass filter cutoff frequency.
+    pretilt_search_range : tuple[float, float]
+        Search range for pretilt estimation in degrees.
+
+    Returns
+    -------
+    float
+        The estimated pretilt value in degrees.
+    """
+    import torch
+    from torch_tiltxcorr import tiltxcorr_with_sample_tilt_estimation
+
+    if device is not None and torch.cuda.is_available():
+        torch.cuda.set_device(device)
+        device_str = f"cuda:{device}"
+    else:
+        device_str = "cuda"
+
+    # Load tilt-series data
+    ts_data = TiltSeriesData(xml_metadata_path=xml_file)
+    ts, stack, pixel_size = ts_data.load_metadata_and_stack(downsample=1)
+
+    # Extract tilt axis angle from metadata (same for all tilts)
+    tilt_axis_angle = ts.tilt_axis_angles[0].item()
+
+    # Run cross-correlation alignment with pretilt estimation
+    shifts, pretilt = tiltxcorr_with_sample_tilt_estimation(
+        tilt_series=stack.to(device_str),
+        tilt_angles=ts.angles.to(device_str),
+        tilt_axis_angle=tilt_axis_angle,
+        pixel_spacing_angstroms=pixel_size,
+        lowpass_angstroms=pixel_size / lowpass_cutoff,
+        sample_tilt_range=pretilt_search_range,
+    )
+
+    # Convert shifts from pixels to Angstroms
+    shifts_angstrom = shifts * pixel_size
+
+    # Apply pretilt to angles
+    ts.angles = ts.angles + pretilt
+
+    # Apply shifts (note: negation and axis assignment)
+    # shifts are in YX order, tilt_axis_offset are X and Y
+    ts.tilt_axis_offset_x = -shifts_angstrom[:, 1]
+    ts.tilt_axis_offset_y = -shifts_angstrom[:, 0]
+
+    # Save updated metadata
+    ts_data.save_metadata_to_xml(ts)
+
+    return float(pretilt)
+
+
+def run_cross_correlation_alignment_parallel(
     training_directory: Path,
-    device: int = 0,
+    devices: list[int] | None = None,
+    n_processes: int = 4,
     lowpass_cutoff: float = 0.25,
     pretilt_search_range: tuple[float, float] = (-30.0, 30.0),
 ) -> None:
     """
-    Run cross-correlation based alignment with pretilt estimation.
+    Run cross-correlation based alignment with pretilt estimation in parallel.
 
     This performs coarse alignment using cross-correlation to estimate shifts
     and sample pretilt (initial tilt offset) for all tilt-series in the training
-    directory.
+    directory, processing multiple tilt-series in parallel across available GPUs.
 
     Parameters
     ----------
     training_directory : Path
         Directory containing XML metadata files for tilt-series.
-    device : int, optional
-        CUDA device to use for alignment (default: 0).
+    devices : list[int] | None, optional
+        List of CUDA device indices to distribute work across. If None, uses
+        default device assignment.
+    n_processes : int, optional
+        Number of parallel processes to use (default: 4).
     lowpass_cutoff : float, optional
         Low-pass filter cutoff frequency (default: 0.25).
     pretilt_search_range : tuple[float, float], optional
@@ -43,42 +117,35 @@ def run_cross_correlation_alignment(
         f"{pretilt_search_range[0]}° to {pretilt_search_range[1]}°"
     )
     print(f"  Low-pass cutoff: {lowpass_cutoff}")
-    print(f"  Using device: cuda:{device}\n")
+    print(f"  Using {n_processes} parallel processes")
+    if devices:
+        print(f"  Distributing across devices: {devices}\n")
+    else:
+        print("  Using default device assignment\n")
 
-    for xml_file in xml_files:
-        print(f"Processing {xml_file.name}...", end=" ", flush=True)
+    # Use explicit spawn context to avoid CUDA issues with fork
+    ctx = mp.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=n_processes, mp_context=ctx) as executor:
+        # Submit all tasks with round-robin device assignment
+        futures = []
+        for i, xml_file in enumerate(xml_files):
+            device = devices[i % len(devices)] if devices else None
+            future = executor.submit(
+                _run_cross_correlation_single,
+                xml_file,
+                device,
+                lowpass_cutoff,
+                pretilt_search_range,
+            )
+            futures.append(future)
 
-        # Load tilt-series data
-        ts_data = TiltSeriesData(xml_metadata_path=xml_file)
-        ts, stack, pixel_size = ts_data.load_metadata_and_stack(downsample=1)
-
-        # Extract tilt axis angle from metadata (same for all tilts)
-        tilt_axis_angle = ts.tilt_axis_angles[0].item()
-
-        # Run cross-correlation alignment with pretilt estimation
-        shifts, pretilt = tiltxcorr_with_sample_tilt_estimation(
-            tilt_series=stack.to(f"cuda:{device}"),
-            tilt_angles=ts.angles.to(f"cuda:{device}"),
-            tilt_axis_angle=tilt_axis_angle,
-            pixel_spacing_angstroms=pixel_size,
-            lowpass_angstroms=pixel_size / lowpass_cutoff,
-            sample_tilt_range=pretilt_search_range,
-        )
-
-        # Convert shifts from pixels to Angstroms
-        shifts_angstrom = shifts * pixel_size
-
-        # Apply pretilt to angles
-        ts.angles = ts.angles + pretilt
-
-        # Apply shifts (note: negation and axis assignment)
-        # shifts are in YX order, tilt_axis_offset are X and Y
-        ts.tilt_axis_offset_x = -shifts_angstrom[:, 1]
-        ts.tilt_axis_offset_y = -shifts_angstrom[:, 0]
-
-        # Save updated metadata
-        ts_data.save_metadata_to_xml(ts)
-
-        print(f"✓ (pretilt: {pretilt:.2f}°)")
+        for future in tqdm(
+            futures,
+            desc="Cross-correlation alignment",
+            unit="tilt series",
+            file=sys.stdout,
+        ):
+            # This will raise any exception that occurred in the worker
+            future.result()
 
     print("\nCross-correlation alignment complete!\n")

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -7,7 +7,6 @@ import typer
 import torch
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch.plugins.environments import SLURMEnvironment
 
 from ._cli import OPTION_PROMPT_KWARGS, cli
 from .data import MissAlignmentDataModule
@@ -222,7 +221,6 @@ def train_miss_align(
             limit_val_batches=0,  # turn on validation steps
             num_sanity_val_steps=0,
             callbacks=[early_stopping, checkpoint_callback, progress_bar],
-            plugins=[SLURMEnvironment(auto_requeue=False)],
             precision="16-mixed",  # Enable automatic mixed precision
         )
 

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -231,6 +231,11 @@ def train_miss_align(
         else:
             model = MissAlignment(**model_params)
 
+        # Convert BatchNorm to SyncBatchNorm for DDP training
+        # This synchronizes batch statistics across all GPUs
+        if len(devices_training) > 1:
+            model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+
         # Initialize data module with parameters from config
         # Divide batch size by number of training devices to maintain
         # effective batch size

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -211,6 +211,7 @@ def train_miss_align(
             num_sanity_val_steps=0,
             callbacks=[early_stopping, checkpoint_callback, progress_bar],
             precision="16-mixed",  # Enable automatic mixed precision
+            use_distributed_sampler=False,  # our dataset is already split
         )
 
         # Initialize model with parameters from config

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -215,8 +215,12 @@ def train_miss_align(
         )
 
         # Initialize model with parameters from config
+        # Scale learning rate by number of GPUs (linear scaling rule)
+        scaled_learning_rate = model_training_config["learning_rate"] * len(
+            devices_training
+        )
         model_params = {
-            "learning_rate": model_training_config["learning_rate"],
+            "learning_rate": scaled_learning_rate,
             "margin": model_training_config["loss_margin"],
             "weight_decay": float(model_training_config["weight_decay"]),
             "warmup_steps": model_training_config["warmup_steps"],
@@ -237,17 +241,8 @@ def train_miss_align(
             model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
         # Initialize data module with parameters from config
-        # Divide batch size by number of training devices to maintain
-        # effective batch size
-        batch_size_per_device = data_module_config["batch_size"] // len(
-            devices_training
-        )
-        if batch_size_per_device < 1:
-            raise ValueError(
-                f"Batch size {data_module_config['batch_size']} is too small for "
-                f"{len(devices_training)} training devices. Increase batch_size "
-                f"in config."
-            )
+        # Each GPU uses the full batch size (effective batch size scales with GPUs)
+        batch_size_per_device = data_module_config["batch_size"]
 
         with MissAlignmentDataModule(
             training_directory,

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -13,13 +13,9 @@ from .data import MissAlignmentDataModule
 from .data.shift_generation import create_default_generator
 from .models import MissAlignment, MAEarlyStopping, MAProgressBar
 from .alignment import run_alignment_parallel
-from .alignment.statistics import (
-    identify_outliers,
-    plot_loss_distribution,
-    filter_outlier_xml_files,
-)
 from .prepare_stacks import prepare_stacks_parallel
 from .preprocessing import run_cross_correlation_alignment
+from .utils import distributed_barrier, is_rank_zero, rank_zero_print
 
 
 def parse_device_list(value: str) -> list[int]:
@@ -70,12 +66,6 @@ def train_miss_align(
         help="Run cross-correlation based alignment before training iterations. "
         "This performs coarse alignment with pretilt estimation.",
     ),
-    filter_outliers: bool = typer.Option(
-        False,
-        help="[Experimental option] Filter out tilt-series "
-        "with alignment loss > mean + 3*std. "
-        "Outliers are moved to iter{N}_outliers/ directory.",
-    ),
 ) -> None:
     """Train MissAlignment on a dataset using configuration from a YAML file."""
 
@@ -86,20 +76,19 @@ def train_miss_align(
     # Parse device lists from comma-separated strings
     devices_training = parse_device_list(training_devices)
     devices_reconstruction = parse_device_list(reconstruction_devices)
-    n_workers = len(devices_reconstruction)
 
     if len(devices_training) < 1:
         raise ValueError("MissAlignment needs at least 1 training device")
-    if n_workers < 1:
+    if len(devices_reconstruction) < 1:
         raise ValueError("MissAlignment needs at least 1 reconstruction worker")
 
     # For alignment stage, use all visible GPUs
     n_visible_gpus = torch.cuda.device_count()
     devices_alignment = list(range(n_visible_gpus))
 
-    print(f"Using devices {devices_training} for training")
-    print(f"Using devices {devices_reconstruction} for reconstruction workers")
-    print(f"Using devices {devices_alignment} for alignment")
+    rank_zero_print(f"Using devices {devices_training} for training")
+    rank_zero_print(f"Using devices {devices_reconstruction} for reconstruction")
+    rank_zero_print(f"Using devices {devices_alignment} for alignment")
 
     # Load configuration from YAML file
     with open(config_file, "r") as f:
@@ -147,7 +136,7 @@ def train_miss_align(
             for xml_file in training_directory.glob("*.xml"):
                 destination = preiter_directory / xml_file.name
                 copyfile(xml_file, destination)
-            print(f"Backed up original metadata to {preiter_directory}")
+            rank_zero_print(f"Backed up original metadata to {preiter_directory}")
 
             # Run cross-correlation alignment on the training directory
             run_cross_correlation_alignment(
@@ -176,9 +165,9 @@ def train_miss_align(
         # ============================================================
         iteration_settings = general_config["iteration_settings"][x]
         alignment_mode = iteration_settings["alignment"]
-        print(f"\n{'=' * 60}")
-        print(f"Iteration {x + 1}/{end_iter} - Alignment mode: {alignment_mode}")
-        print(f"{'=' * 60}\n")
+        rank_zero_print(f"\n{'=' * 60}")
+        rank_zero_print(f"Iteration {x + 1}/{end_iter} - Alignment: {alignment_mode}")
+        rank_zero_print(f"{'=' * 60}\n")
 
         # Define the early stopping callback
         early_stopping = MAEarlyStopping(
@@ -257,8 +246,8 @@ def train_miss_align(
         with MissAlignmentDataModule(
             training_directory,
             create_default_generator(**shift_generation_config),
-            n_workers=n_workers,
             reconstruction_accelerators=devices_reconstruction,
+            n_training_devices=len(devices_training),
             batch_size=batch_size_per_device,
             patch_size=data_module_config["patch_size"],
             apply_ctf=general_config["apply_ctf"],
@@ -271,79 +260,66 @@ def train_miss_align(
             # enter datamodule context to start the reconstruction worker pool
             trainer.fit(model, train_dataloaders=training_data)
 
-        print(
-            f"Best model after training iteration {x}:",
-            trainer.checkpoint_callback.best_model_path,
-        )
-        # update the config with the trained model
-        model_training_config["model_checkpoint"] = (
-            trainer.checkpoint_callback.best_model_path
-        )
+        # Synchronize all ranks after training before non-distributed operations
+        distributed_barrier()
 
-        # copy best model to training directory as model.ckpt
-        best_model_path = Path(trainer.checkpoint_callback.best_model_path)
-        training_model_path = training_directory / "model.ckpt"
-        copyfile(best_model_path, training_model_path)
-        print(f"Copied best model to {training_model_path}")
+        # Only rank 0 performs alignment and file operations
+        # Other ranks wait at the barrier at the end of the iteration
+        if is_rank_zero():
+            best_model_path = Path(trainer.checkpoint_callback.best_model_path)
+            rank_zero_print(f"Best model after iteration {x}:", best_model_path)
 
-        # ============================================================
-        # =============== tilt-series alignment step =================
-        # ============================================================
+            # copy best model to training directory as model.ckpt
+            # This known path is used by all ranks for the next iteration
+            training_model_path = training_directory / "model.ckpt"
+            copyfile(best_model_path, training_model_path)
+            rank_zero_print(f"Copied best model to {training_model_path}")
 
-        # get list of all files to process for alignment
-        tilt_series_list = list(training_directory.glob("*.xml"))
+            # ============================================================
+            # =============== tilt-series alignment step =================
+            # ============================================================
 
-        # run alignment in parallel over all available devices
-        alignment_losses = run_alignment_parallel(
-            model_checkpoint=model_training_config["model_checkpoint"],
-            tilt_series_list=tilt_series_list,
-            output_directory=training_directory,
-            setting=iteration_settings["alignment"],
-            patch_size=alignment_config["patch_size"],
-            patch_overlap=alignment_config["patch_overlap"],
-            batch_size=alignment_config["batch_size"],
-            apply_ctf=general_config["apply_ctf"],
-            downsample=iteration_settings["downsample"],
-            devices_list=devices_alignment,
-        )
+            # get list of all files to process for alignment
+            tilt_series_list = list(training_directory.glob("*.xml"))
 
-        # Plot loss distribution
-        plot_path = training_directory / f"iter{x + 1}_alignment_losses.png"
-        plot_loss_distribution(
-            losses=alignment_losses,
-            output_path=plot_path,
-            n_std=3.0,
-            iteration=x + 1,
-        )
-
-        # Filter outliers if requested
-        if filter_outliers:
-            outliers, mean_loss, std_loss = identify_outliers(
-                alignment_losses, n_std=3.0
+            # run alignment in parallel over all available devices
+            run_alignment_parallel(
+                model_checkpoint=str(training_model_path),
+                tilt_series_list=tilt_series_list,
+                output_directory=training_directory,
+                setting=iteration_settings["alignment"],
+                patch_size=alignment_config["patch_size"],
+                patch_overlap=alignment_config["patch_overlap"],
+                batch_size=alignment_config["batch_size"],
+                apply_ctf=general_config["apply_ctf"],
+                downsample=iteration_settings["downsample"],
+                devices_list=devices_alignment,
             )
-            if outliers:
-                print(f"\nFiltering {len(outliers)} outlier tilt-series:")
-                filter_outlier_xml_files(
-                    training_directory=training_directory,
-                    outliers=outliers,
-                    iteration=x + 1,
-                )
 
-        # make copies of the xml files and model after alignment
-        iteration_directory = training_directory / ("iter" + str(x + 1))
-        iteration_directory.mkdir(parents=True, exist_ok=True)
+            # make copies of the xml files and model after alignment
+            iteration_directory = training_directory / ("iter" + str(x + 1))
+            iteration_directory.mkdir(parents=True, exist_ok=True)
 
-        for xml_file in training_directory.glob("*.xml"):
-            destination_xml = iteration_directory / xml_file.name
-            copyfile(xml_file, destination_xml)
+            for xml_file in training_directory.glob("*.xml"):
+                destination_xml = iteration_directory / xml_file.name
+                copyfile(xml_file, destination_xml)
 
-            # copy the file with the alignment loss
-            loss_json = xml_file.stem + "_alignment_loss.json"
-            destination_json = iteration_directory / loss_json
-            copyfile(training_directory / loss_json, destination_json)
+                # copy the file with the alignment loss
+                loss_json = xml_file.stem + "_alignment_loss.json"
+                destination_json = iteration_directory / loss_json
+                copyfile(training_directory / loss_json, destination_json)
 
-        training_model_path = iteration_directory / "model.ckpt"
-        copyfile(best_model_path, training_model_path)
-        print(f"Copied best model to {training_model_path}")
+            iteration_model_path = iteration_directory / "model.ckpt"
+            copyfile(best_model_path, iteration_model_path)
+            rank_zero_print(f"Copied best model to {iteration_model_path}")
+
+        # All ranks use the known model.ckpt path for the next iteration
+        # (rank 0 wrote it above, barrier below ensures it exists)
+        model_training_config["model_checkpoint"] = str(
+            training_directory / "model.ckpt"
+        )
+
+        # Synchronize all ranks before starting the next iteration
+        distributed_barrier()
 
     return None

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -23,24 +23,32 @@ from .prepare_stacks import prepare_stacks_parallel
 from .preprocessing import run_cross_correlation_alignment
 
 
+def parse_device_list(value: str) -> list[int]:
+    """Parse comma-separated device list like '0,1,2' into [0, 1, 2]."""
+    return [int(x.strip()) for x in value.split(",")]
+
+
 @cli.command(name="train", no_args_is_help=True)
 def train_miss_align(
     config_file: Path = typer.Option("config_template.yaml", **OPTION_PROMPT_KWARGS),
-    n_workers: int = typer.Option(
-        2,
-        help="Number of workers that feed subtomogram reconstructions "
-        "to the data pool for training the CNN. Workers will be "
-        "divided across the available GPU devices, where multiple "
-        "workers per GPU are allowed.",
+    training_devices: str = typer.Option(
+        "0",
+        help="Comma-separated list of GPU device indices for model training. "
+        "For multi-GPU training, specify multiple devices (e.g., '0,1'). "
+        "The batch size from config will be divided by the number of "
+        "training devices to maintain the same effective batch size.",
     ),
-    n_devices: int = typer.Option(
-        1,
-        help="Number of GPU devices available for miss-alignment. "
-        "GPU's are index from 0 to n and the system GPU's should be "
-        "restricted with CUDA_VISIBLE_DEVICES before the command. "
-        "One GPU's is always used to train the CNN, the others are "
-        "split across the workers. If a single GPU is provided both "
-        "the model and workers will use the same GPU.",
+    reconstruction_devices: str = typer.Option(
+        "0",
+        help="Comma-separated list of GPU device indices for reconstruction workers. "
+        "Each entry spawns one worker on that device. Devices can be repeated "
+        "to run multiple workers per GPU (e.g., '0,0,1,1' runs 2 workers each "
+        "on GPU 0 and GPU 1). Can overlap with training devices if needed.",
+    ),
+    dataloader_workers_per_training_device: int = typer.Option(
+        2,
+        help="Number of CPU DataLoader workers per training device. "
+        "Total DataLoader workers = this value × number of training devices.",
     ),
     pool_size: int = typer.Option(
         1000,
@@ -76,25 +84,23 @@ def train_miss_align(
     # cpu multithreading
     torch.set_num_threads(1)
 
-    # gpu devices is a number of available devices for processing
-    # the devices should be limited by CUDA_VISIBLE_DEVICES
-    if n_devices < 1:
-        raise ValueError("MissAlignment needs at least 1 GPU")
-    devices_list = list(range(n_devices))
+    # Parse device lists from comma-separated strings
+    devices_training = parse_device_list(training_devices)
+    devices_reconstruction = parse_device_list(reconstruction_devices)
+    n_workers = len(devices_reconstruction)
 
-    devices_training = devices_list[0:1]
-    print(f"Using device {devices_training[0]} for training")
+    if len(devices_training) < 1:
+        raise ValueError("MissAlignment needs at least 1 training device")
+    if n_workers < 1:
+        raise ValueError("MissAlignment needs at least 1 reconstruction worker")
 
-    if len(devices_list) == 1:
-        devices_reconstruction = devices_list * n_workers
-    else:
-        # distribute remaining devices equally among reconstruction workers,
-        # cycling through devices if there are fewer devices than workers
-        devices_remaining = devices_list[1:]
-        devices_reconstruction = [
-            devices_remaining[i % len(devices_remaining)] for i in range(n_workers)
-        ]
+    # For alignment stage, use all visible GPUs
+    n_visible_gpus = torch.cuda.device_count()
+    devices_alignment = list(range(n_visible_gpus))
+
+    print(f"Using devices {devices_training} for training")
     print(f"Using devices {devices_reconstruction} for reconstruction workers")
+    print(f"Using devices {devices_alignment} for alignment")
 
     # Load configuration from YAML file
     with open(config_file, "r") as f:
@@ -119,7 +125,7 @@ def train_miss_align(
             training_directory=training_directory,
             desired_pixel_size=prepare_stacks,
             n_processes=4,
-            devices=devices_list,
+            devices=devices_alignment,
         )
 
     # Set up training environment
@@ -201,9 +207,12 @@ def train_miss_align(
         )
 
         # Set up trainer with parameters from config
+        # Use DDP strategy for multi-GPU training
+        strategy = "ddp" if len(devices_training) > 1 else "auto"
         trainer = Trainer(
             accelerator="gpu",
-            devices=devices_training,  # use the 0 device
+            devices=devices_training,
+            strategy=strategy,
             default_root_dir=training_directory / "models",
             max_epochs=max_epochs,
             log_every_n_steps=50,
@@ -235,17 +244,30 @@ def train_miss_align(
             model = MissAlignment(**model_params)
 
         # Initialize data module with parameters from config
+        # Divide batch size by number of training devices to maintain
+        # effective batch size
+        batch_size_per_device = data_module_config["batch_size"] // len(
+            devices_training
+        )
+        if batch_size_per_device < 1:
+            raise ValueError(
+                f"Batch size {data_module_config['batch_size']} is too small for "
+                f"{len(devices_training)} training devices. Increase batch_size "
+                f"in config."
+            )
+
         with MissAlignmentDataModule(
             training_directory,
             create_default_generator(**shift_generation_config),
             n_workers=n_workers,
             reconstruction_accelerators=devices_reconstruction,
-            batch_size=data_module_config["batch_size"],
+            batch_size=batch_size_per_device,
             patch_size=data_module_config["patch_size"],
             apply_ctf=general_config["apply_ctf"],
             downsample=iteration_settings["downsample"],
             steps_per_epoch=data_module_config["steps_per_epoch"],
             pool_size=pool_size,
+            dataloader_workers=dataloader_workers_per_training_device,
         ) as dm:
             training_data = dm.train_dataloader()
             # enter datamodule context to start the reconstruction worker pool
@@ -284,7 +306,7 @@ def train_miss_align(
             batch_size=alignment_config["batch_size"],
             apply_ctf=general_config["apply_ctf"],
             downsample=iteration_settings["downsample"],
-            devices_list=devices_list,
+            devices_list=devices_alignment,
         )
 
         # Plot loss distribution

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -17,7 +17,7 @@ from .data.shift_generation import create_default_generator
 from .models import MissAlignment, MAEarlyStopping, MAProgressBar
 from .alignment import run_alignment_parallel
 from .prepare_stacks import prepare_stacks_parallel
-from .preprocessing import run_cross_correlation_alignment
+from .preprocessing import run_cross_correlation_alignment_parallel
 from .utils import distributed_barrier, is_rank_zero, rank_zero_print
 
 
@@ -68,6 +68,11 @@ def train_miss_align(
         False,
         help="Run cross-correlation based alignment before training iterations. "
         "This performs coarse alignment with pretilt estimation.",
+    ),
+    ddp_timeout_hours: float = typer.Option(
+        6.0,
+        help="Timeout in hours for DDP communication during multi-GPU training. "
+        "Increase this if alignment takes longer than expected.",
     ),
 ) -> None:
     """Train MissAlignment on a dataset using configuration from a YAML file."""
@@ -143,9 +148,10 @@ def train_miss_align(
                 rank_zero_print(f"Backed up original metadata to {preiter_directory}")
 
                 # Run cross-correlation alignment on the training directory
-                run_cross_correlation_alignment(
+                run_cross_correlation_alignment_parallel(
                     training_directory=training_directory,
-                    device=devices_training[0],
+                    devices=devices_alignment,
+                    n_processes=4,
                 )
 
     start_iter = start_at_iteration
@@ -202,7 +208,7 @@ def train_miss_align(
         # Use DDP strategy for multi-GPU training with extended timeout
         # Default is 30 min, but alignment can take much longer while other ranks wait
         strategy = (
-            DDPStrategy(timeout=timedelta(days=7))
+            DDPStrategy(timeout=timedelta(hours=ddp_timeout_hours))
             if len(devices_training) > 1
             else "auto"
         )

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -260,8 +260,10 @@ def train_miss_align(
             # enter datamodule context to start the reconstruction worker pool
             trainer.fit(model, train_dataloaders=training_data)
 
-        # Synchronize all ranks after training before non-distributed operations
-        distributed_barrier()
+            # Synchronize all ranks after training, while DDP is still active
+            # This must be BEFORE the context manager exits, as Lightning's DDP
+            # process group may become invalid during/after teardown
+            distributed_barrier()
 
         # Only rank 0 performs alignment and file operations
         # Other ranks wait at the barrier at the end of the iteration

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -211,7 +211,6 @@ def train_miss_align(
             num_sanity_val_steps=0,
             callbacks=[early_stopping, checkpoint_callback, progress_bar],
             precision="16-mixed",  # Enable automatic mixed precision
-            use_distributed_sampler=False,  # our dataset is already split
         )
 
         # Initialize model with parameters from config

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -234,11 +234,6 @@ def train_miss_align(
         else:
             model = MissAlignment(**model_params)
 
-        # Convert BatchNorm to SyncBatchNorm for DDP training
-        # This synchronizes batch statistics across all GPUs
-        if len(devices_training) > 1:
-            model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
-
         # Initialize data module with parameters from config
         # Each GPU uses the full batch size (effective batch size scales with GPUs)
         batch_size_per_device = data_module_config["batch_size"]

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -256,9 +256,9 @@ def train_miss_align(
             pool_size=pool_size,
             dataloader_workers=dataloaders_per_trainer,
         ) as dm:
-            training_data = dm.train_dataloader()
             # enter datamodule context to start the reconstruction worker pool
-            trainer.fit(model, train_dataloaders=training_data)
+            # passing datamodule lets Lightning apply DistributedSampler
+            trainer.fit(model, datamodule=dm)
 
             # Synchronize all ranks after training, while DDP is still active
             # This must be BEFORE the context manager exits, as Lightning's DDP

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -108,44 +108,45 @@ def train_miss_align(
     training_directory = Path(general_config["training_directory"])
     training_directory.mkdir(exist_ok=True, parents=True)
 
-    # Prepare tilt stacks if requested
-    if prepare_stacks is not None:
-        if prepare_stacks <= 0:
-            raise ValueError("--prepare-stacks must be a positive non-zero number")
-        prepare_stacks_parallel(
-            training_directory=training_directory,
-            desired_pixel_size=prepare_stacks,
-            n_processes=4,
-            devices=devices_alignment,
-        )
-
     # Set up training environment
     torch.set_float32_matmul_precision("medium")
     seed = general_config["seed"]
     seed_everything(seed, workers=True)
 
-    # Run preprocessing if requested
-    if preprocess:
-        if start_at_iteration != 0:
-            raise ValueError(
-                "Running preprocessing at while "
-                "not starting at iteration 0. This "
-                "is likely not desirable behaviour."
-            )
-        else:
-            # Back up original data to pre-iter directory
-            preiter_directory = training_directory / "pre-iter"
-            preiter_directory.mkdir(parents=True, exist_ok=True)
-            for xml_file in training_directory.glob("*.xml"):
-                destination = preiter_directory / xml_file.name
-                copyfile(xml_file, destination)
-            rank_zero_print(f"Backed up original metadata to {preiter_directory}")
-
-            # Run cross-correlation alignment on the training directory
-            run_cross_correlation_alignment(
+    if is_rank_zero():
+        # Prepare tilt stacks if requested
+        if prepare_stacks is not None:
+            if prepare_stacks <= 0:
+                raise ValueError("--prepare-stacks must be a positive non-zero number")
+            prepare_stacks_parallel(
                 training_directory=training_directory,
-                device=devices_training[0],
+                desired_pixel_size=prepare_stacks,
+                n_processes=4,
+                devices=devices_alignment,
             )
+
+        # Run preprocessing if requested
+        if preprocess:
+            if start_at_iteration != 0:
+                raise ValueError(
+                    "Running preprocessing at while "
+                    "not starting at iteration 0. This "
+                    "is likely not desirable behaviour."
+                )
+            else:
+                # Back up original data to pre-iter directory
+                preiter_directory = training_directory / "pre-iter"
+                preiter_directory.mkdir(parents=True, exist_ok=True)
+                for xml_file in training_directory.glob("*.xml"):
+                    destination = preiter_directory / xml_file.name
+                    copyfile(xml_file, destination)
+                rank_zero_print(f"Backed up original metadata to {preiter_directory}")
+
+                # Run cross-correlation alignment on the training directory
+                run_cross_correlation_alignment(
+                    training_directory=training_directory,
+                    device=devices_training[0],
+                )
 
     start_iter = start_at_iteration
     end_iter = len(general_config["iteration_settings"])

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -5,8 +5,11 @@ import yaml
 
 import typer
 import torch
+from datetime import timedelta
+
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.strategies import DDPStrategy
 
 from ._cli import OPTION_PROMPT_KWARGS, cli
 from .data import MissAlignmentDataModule
@@ -195,8 +198,13 @@ def train_miss_align(
         )
 
         # Set up trainer with parameters from config
-        # Use DDP strategy for multi-GPU training
-        strategy = "ddp" if len(devices_training) > 1 else "auto"
+        # Use DDP strategy for multi-GPU training with extended timeout
+        # Default is 30 min, but alignment can take much longer while other ranks wait
+        strategy = (
+            DDPStrategy(timeout=timedelta(days=7))
+            if len(devices_training) > 1
+            else "auto"
+        )
         trainer = Trainer(
             accelerator="gpu",
             devices=devices_training,

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -44,7 +44,7 @@ def train_miss_align(
         "to run multiple workers per GPU (e.g., '0,0,1,1' runs 2 workers each "
         "on GPU 0 and GPU 1). Can overlap with training devices if needed.",
     ),
-    dataloader_workers_per_training_device: int = typer.Option(
+    dataloaders_per_trainer: int = typer.Option(
         2,
         help="Number of CPU DataLoader workers per training device. "
         "Total DataLoader workers = this value × number of training devices.",
@@ -265,7 +265,7 @@ def train_miss_align(
             downsample=iteration_settings["downsample"],
             steps_per_epoch=data_module_config["steps_per_epoch"],
             pool_size=pool_size,
-            dataloader_workers=dataloader_workers_per_training_device,
+            dataloader_workers=dataloaders_per_trainer,
         ) as dm:
             training_data = dm.train_dataloader()
             # enter datamodule context to start the reconstruction worker pool

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for miss-alignment."""
+
+import os
+
+import torch
+
+
+def is_rank_zero() -> bool:
+    """Check if we're on the main process (rank 0) in DDP.
+
+    This checks both torch.distributed (if initialized) and the LOCAL_RANK
+    environment variable (set by DDP launchers before script execution).
+    """
+    if torch.distributed.is_initialized():
+        return torch.distributed.get_rank() == 0
+    # Check LOCAL_RANK env var (set by DDP launcher before torch.distributed init)
+    local_rank = os.environ.get("LOCAL_RANK")
+    if local_rank is not None:
+        return int(local_rank) == 0
+    return True
+
+
+def rank_zero_print(*args, **kwargs) -> None:
+    """Print only on rank 0 in DDP training.
+
+    All arguments are passed directly to the built-in print function.
+    """
+    if is_rank_zero():
+        print(*args, **kwargs)
+
+
+def distributed_barrier() -> None:
+    """Synchronize all processes in distributed training.
+
+    This is a no-op if distributed training is not initialized (single GPU).
+    Use this to ensure all ranks wait before/after non-distributed operations.
+    """
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -36,4 +36,8 @@ def distributed_barrier() -> None:
     Use this to ensure all ranks wait before/after non-distributed operations.
     """
     if torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+        world_size = torch.distributed.get_world_size()
+        print(f"[Rank {rank}] Entering barrier (world_size={world_size})")
         torch.distributed.barrier()
+        print(f"[Rank {rank}] Exited barrier")

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -8,15 +8,27 @@ import torch
 def is_rank_zero() -> bool:
     """Check if we're on the main process (rank 0) in DDP.
 
-    This checks both torch.distributed (if initialized) and the LOCAL_RANK
-    environment variable (set by DDP launchers before script execution).
+    This checks torch.distributed (if initialized), then global rank environment
+    variables (RANK, SLURM_PROCID), and finally LOCAL_RANK as a fallback.
+
+    Note: LOCAL_RANK is per-node, so on multi-node SLURM jobs each node would
+    have a LOCAL_RANK=0. We prioritize global rank variables to avoid multiple
+    processes thinking they're rank 0.
     """
     if torch.distributed.is_initialized():
         return torch.distributed.get_rank() == 0
-    # Check LOCAL_RANK env var (set by DDP launcher before torch.distributed init)
+
+    # Check global rank env vars (set by various launchers including SLURM)
+    for var in ("RANK", "SLURM_PROCID"):
+        rank = os.environ.get(var)
+        if rank is not None:
+            return int(rank) == 0
+
+    # LOCAL_RANK is per-node, only use as last resort for single-node
     local_rank = os.environ.get("LOCAL_RANK")
     if local_rank is not None:
         return int(local_rank) == 0
+
     return True
 
 

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -36,8 +36,4 @@ def distributed_barrier() -> None:
     Use this to ensure all ranks wait before/after non-distributed operations.
     """
     if torch.distributed.is_initialized():
-        rank = torch.distributed.get_rank()
-        world_size = torch.distributed.get_world_size()
-        print(f"[Rank {rank}] Entering barrier (world_size={world_size})")
         torch.distributed.barrier()
-        print(f"[Rank {rank}] Exited barrier")

--- a/tests/data/test_pool_dataset.py
+++ b/tests/data/test_pool_dataset.py
@@ -66,25 +66,35 @@ class TestReconstructionPoolDataset:
             dataset._list_partition_files()
 
     def test_list_partition_files(self, dataset, mock_pool_dir, sample_data):
-        """Test that _list_partition_files returns correct files."""
-        # Create some test files
-        for i in range(5):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+        """Test that _list_partition_files returns correct files.
+
+        Files follow the naming:
+        partition_{partition_id}_worker_{worker_id}_seq_{seq_id}.pickle
+        """
+        # Create some test files from worker 0
+        for i in range(3):
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
+            with open(file_path, "wb") as f:
+                pickle.dump(sample_data, f)
+
+        # Create some test files from worker 1 (same partition)
+        for i in range(2):
+            file_path = mock_pool_dir / f"partition_0_worker_1_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 
         # Create a file for different partition (should be ignored)
-        other_file = mock_pool_dir / "partition_1_seq_0.pickle"
+        other_file = mock_pool_dir / "partition_1_worker_0_seq_0.pickle"
         with open(other_file, "wb") as f:
             pickle.dump(sample_data, f)
 
         # Create a temp file (should be filtered out)
-        tmp_file = mock_pool_dir / "tmp_partition_0_xyz.pickle"
+        tmp_file = mock_pool_dir / "tmp_partition_0_worker_0_xyz.pickle"
         with open(tmp_file, "wb") as f:
             pickle.dump(sample_data, f)
 
         files = dataset._list_partition_files()
-        assert len(files) == 5
+        assert len(files) == 5  # 3 from worker 0 + 2 from worker 1
         assert all("partition_0" in f.name for f in files)
         assert all(not f.name.startswith("tmp_") for f in files)
 
@@ -92,7 +102,7 @@ class TestReconstructionPoolDataset:
         """Test that __getitem__ reads file and deletes it after."""
         # Create enough files to meet batch_size threshold
         for i in range(5):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 
@@ -114,7 +124,7 @@ class TestReconstructionPoolDataset:
         """Test that volumes are converted from fp16 to fp32."""
         # Create test files
         for i in range(5):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 
@@ -128,7 +138,7 @@ class TestReconstructionPoolDataset:
         """Test that __getitem__ waits when not enough files available."""
         # Start with fewer files than batch_size
         for i in range(2):  # Less than batch_size=4
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 
@@ -138,7 +148,7 @@ class TestReconstructionPoolDataset:
         def add_files():
             time.sleep(0.1)  # Wait a bit
             for i in range(2, 5):  # Add more files
-                file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+                file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
                 with open(file_path, "wb") as f:
                     pickle.dump(sample_data, f)
 
@@ -195,7 +205,7 @@ class TestReconstructionPoolDataset:
         """Test that channel dimension is added correctly."""
         # Create test files
         for i in range(5):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 
@@ -212,7 +222,7 @@ class TestReconstructionPoolDataset:
         invalid_data = [(torch.randn(64, 64, 64).half(), 1) for _ in range(3)]
 
         for i in range(5):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(invalid_data, f)
 
@@ -225,13 +235,13 @@ class TestReconstructionPoolDataset:
     def test_corrupted_file_retry(self, dataset, mock_pool_dir, sample_data):
         """Test that corrupted files trigger retry."""
         # Create a corrupted file
-        corrupted_path = mock_pool_dir / "partition_0_seq_0.pickle"
+        corrupted_path = mock_pool_dir / "partition_0_worker_0_seq_0.pickle"
         with open(corrupted_path, "wb") as f:
             f.write(b"corrupted data")
 
         # Create valid files
         for i in range(1, 6):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 
@@ -243,7 +253,7 @@ class TestReconstructionPoolDataset:
         """Test that FileNotFoundError (race condition) triggers retry."""
         # Create valid files
         for i in range(5):
-            file_path = mock_pool_dir / f"partition_0_seq_{i}.pickle"
+            file_path = mock_pool_dir / f"partition_0_worker_0_seq_{i}.pickle"
             with open(file_path, "wb") as f:
                 pickle.dump(sample_data, f)
 

--- a/tests/data/test_pool_dataset.py
+++ b/tests/data/test_pool_dataset.py
@@ -2,8 +2,7 @@ import pytest
 import torch
 import pickle
 import time
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from miss_alignment.data.training_dataset import ReconstructionPoolDataset
 
@@ -29,7 +28,7 @@ class TestReconstructionPoolDataset:
     def dataset(self, mock_pool_dir):
         """Create dataset instance with test parameters."""
         ds = ReconstructionPoolDataset(
-            pool_dir=mock_pool_dir, batch_size=4, epoch_size=100
+            pool_dir=mock_pool_dir, batch_size=4, epoch_size=100, n_partitions=1
         )
         ds.partition_id = 0  # Simulate worker_init_fn assignment
         return ds
@@ -38,14 +37,19 @@ class TestReconstructionPoolDataset:
         """Test dataset initialization."""
         batch_size = 4
         epoch_size = 100
+        n_partitions = 2
 
         dataset = ReconstructionPoolDataset(
-            pool_dir=mock_pool_dir, batch_size=batch_size, epoch_size=epoch_size
+            pool_dir=mock_pool_dir,
+            batch_size=batch_size,
+            epoch_size=epoch_size,
+            n_partitions=n_partitions,
         )
 
         assert dataset.pool_dir == mock_pool_dir
         assert dataset.batch_size == batch_size
         assert dataset.epoch_size == epoch_size
+        assert dataset.n_partitions == n_partitions
         assert dataset.partition_id is None  # Not set until worker_init_fn
 
     def test_len(self, dataset):
@@ -55,7 +59,7 @@ class TestReconstructionPoolDataset:
     def test_partition_id_not_set_raises_error(self, mock_pool_dir):
         """Test that accessing partition files without partition_id raises error."""
         dataset = ReconstructionPoolDataset(
-            pool_dir=mock_pool_dir, batch_size=4, epoch_size=100
+            pool_dir=mock_pool_dir, batch_size=4, epoch_size=100, n_partitions=1
         )
         # partition_id is None
         with pytest.raises(RuntimeError, match="partition_id not set"):

--- a/tests/data/test_reconstruction_worker.py
+++ b/tests/data/test_reconstruction_worker.py
@@ -405,18 +405,27 @@ class TestCountPartitionFiles:
     """Test partition file counting."""
 
     def test_count_partition_files(self, temp_dir):
-        """Test counting files in a partition."""
-        # Create some partition files
-        for i in range(5):
-            (temp_dir / f"partition_0_seq_{i}.pickle").touch()
+        """Test counting files in a partition.
+
+        Files are named: partition_{partition_id}_worker_{worker_id}_seq_{seq_id}.pickle
+        Multiple workers can write to the same partition.
+        """
+        # Create some partition files from worker 0
+        for i in range(3):
+            (temp_dir / f"partition_0_worker_0_seq_{i}.pickle").touch()
+
+        # Create some partition files from worker 1 (same partition)
+        for i in range(2):
+            (temp_dir / f"partition_0_worker_1_seq_{i}.pickle").touch()
 
         # Create files for another partition
         for i in range(3):
-            (temp_dir / f"partition_1_seq_{i}.pickle").touch()
+            (temp_dir / f"partition_1_worker_0_seq_{i}.pickle").touch()
 
         # Create a temp file (starts with tmp_ so won't match pattern)
-        (temp_dir / "tmp_partition_0_xyz.pickle").touch()
+        (temp_dir / "tmp_partition_0_worker_0_xyz.pickle").touch()
 
+        # Partition 0 should have 5 files (3 from worker 0 + 2 from worker 1)
         assert _count_partition_files(temp_dir, 0) == 5
         assert _count_partition_files(temp_dir, 1) == 3
         assert _count_partition_files(temp_dir, 2) == 0
@@ -486,8 +495,13 @@ class TestReconstructionWorker:
     def test_worker_writes_partition_files(
         self, mock_fetcher_class, temp_dir, shift_generator, mock_tilt_series_data
     ):
-        """Test that worker writes files with correct partition naming."""
-        partition_id = 0
+        """Test that worker writes files with correct partition naming.
+
+        Worker cycles through all partitions in round-robin order.
+        File naming: partition_{partition_id}_worker_{worker_id}_seq_{seq_id}.pickle
+        """
+        worker_id = 0
+        n_partitions = 2
         partition_size = 10
         stop_event = mp.Event()
 
@@ -530,7 +544,8 @@ class TestReconstructionWorker:
             side_effect=mock_create,
         ):
             reconstruction_worker(
-                partition_id=partition_id,
+                worker_id=worker_id,
+                n_partitions=n_partitions,
                 partition_size=partition_size,
                 pool_dir=temp_dir,
                 tilt_series_xmls=[mock_tilt_series_data],
@@ -543,7 +558,8 @@ class TestReconstructionWorker:
             )
 
         # Check that files were created with correct naming
-        files = list(temp_dir.glob(f"partition_{partition_id}_seq_*.pickle"))
+        # (distributed across partitions)
+        files = list(temp_dir.glob(f"partition_*_worker_{worker_id}_seq_*.pickle"))
         assert len(files) == 8  # 2 calls × 4 triplets
 
         # Verify file contents
@@ -555,17 +571,19 @@ class TestReconstructionWorker:
                 assert data[0][0].dtype == torch.float16
 
     @patch("miss_alignment.data._reconstruction_worker.TiltSeriesFetcher")
-    def test_worker_pauses_when_partition_full(
+    def test_worker_pauses_when_all_partitions_full(
         self, mock_fetcher_class, temp_dir, shift_generator, mock_tilt_series_data
     ):
-        """Test that worker pauses when partition is full."""
-        partition_id = 0
+        """Test that worker pauses when all partitions are full."""
+        worker_id = 0
+        n_partitions = 2
         partition_size = 5  # Small partition
         stop_event = mp.Event()
 
-        # Pre-fill the partition
-        for i in range(partition_size):
-            (temp_dir / f"partition_{partition_id}_seq_{i}.pickle").touch()
+        # Pre-fill all partitions
+        for partition_id in range(n_partitions):
+            for i in range(partition_size):
+                (temp_dir / f"partition_{partition_id}_worker_0_seq_{i}.pickle").touch()
 
         # Create mock returns
         mock_tilt_series = Mock(spec=TiltSeries)
@@ -606,7 +624,8 @@ class TestReconstructionWorker:
             side_effect=mock_create,
         ):
             reconstruction_worker(
-                partition_id=partition_id,
+                worker_id=worker_id,
+                n_partitions=n_partitions,
                 partition_size=partition_size,
                 pool_dir=temp_dir,
                 tilt_series_xmls=[mock_tilt_series_data],
@@ -621,15 +640,16 @@ class TestReconstructionWorker:
         stop_thread.join()
 
         # Worker should have been paused (no reconstruction created)
-        # because partition was already full
+        # because all partitions were already full
         assert create_call_count == 0
 
     @patch("miss_alignment.data._reconstruction_worker.TiltSeriesFetcher")
     def test_worker_sequential_ids_increment(
         self, mock_fetcher_class, temp_dir, shift_generator, mock_tilt_series_data
     ):
-        """Test that sequential IDs increment correctly."""
-        partition_id = 0
+        """Test that sequential IDs increment correctly for a worker."""
+        worker_id = 0
+        n_partitions = 2
         partition_size = 100
         stop_event = mp.Event()
 
@@ -661,7 +681,8 @@ class TestReconstructionWorker:
             side_effect=mock_create,
         ):
             reconstruction_worker(
-                partition_id=partition_id,
+                worker_id=worker_id,
+                n_partitions=n_partitions,
                 partition_size=partition_size,
                 pool_dir=temp_dir,
                 tilt_series_xmls=[mock_tilt_series_data],
@@ -673,14 +694,14 @@ class TestReconstructionWorker:
                 tilt_series_refresh_rate=10,
             )
 
-        # Check sequential IDs
-        files = sorted(temp_dir.glob(f"partition_{partition_id}_seq_*.pickle"))
+        # Check sequential IDs (files are distributed across partitions)
+        files = sorted(temp_dir.glob(f"partition_*_worker_{worker_id}_seq_*.pickle"))
         assert len(files) == 16  # 4 calls × 4 triplets
 
         # Extract IDs and verify they're sequential
         ids = []
         for f in files:
-            # Extract ID from "partition_0_seq_X.pickle"
+            # Extract ID from "partition_X_worker_Y_seq_Z.pickle"
             id_str = f.stem.split("_")[-1]
             ids.append(int(id_str))
 


### PR DESCRIPTION
Add distributed parallel training and some other improvements to have more control over how trainers, reconstruction workers and dataloaders are divided. 

I switched to groupnorm instead of batchnorm to circumvent the normalization issues that we otherwise expected.

Time per training iteration now went from 2 hours to half an hour on the 4 gpu workstation here. With early stopping, its about 25 minutes for training per macro-iteration. I will paste my run command below to see for you if the CLI makes sense.

Also running on SHREC to see if the results remain consistent.