### PR TITLE
Fix reconstruction worker crash on transient MRC read failure

### DIFF
--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -59,12 +59,26 @@ class TiltSeriesFetcher:
         self._tilt_series.tilt_axis_offset_y = self._tmp_tilt_axis_offset_y.clone()
 
     def _load_next(self):
-        tilt_series_data = TiltSeriesData(
-            xml_metadata_path=random.choice(self.tilt_series_xmls)
-        )
-        tilt_series, images, pixel_size = tilt_series_data.load_metadata_and_stack(
-            downsample=self.downsample
-        )
+        max_retries = 5
+        for attempt in range(max_retries):
+            try:
+                tilt_series_data = TiltSeriesData(
+                    xml_metadata_path=random.choice(self.tilt_series_xmls)
+                )
+                tilt_series, images, pixel_size = (
+                    tilt_series_data.load_metadata_and_stack(downsample=self.downsample)
+                )
+                break
+            except (ValueError, OSError) as e:
+                if attempt < max_retries - 1:
+                    time.sleep(PAUSE_POLL_INTERVAL * (2**attempt))
+                elif self._tilt_series is not None:
+                    # Keep using the previously loaded data rather than crashing
+                    return
+                else:
+                    raise RuntimeError(
+                        f"Failed to load tilt-series after {max_retries} attempts"
+                    ) from e
         # run the preprocessing from warp for consistency
         images = preprocess_tilt_data(
             tilt_data=images,

--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -59,26 +59,13 @@ class TiltSeriesFetcher:
         self._tilt_series.tilt_axis_offset_y = self._tmp_tilt_axis_offset_y.clone()
 
     def _load_next(self):
-        max_retries = 5
-        for attempt in range(max_retries):
-            try:
-                tilt_series_data = TiltSeriesData(
-                    xml_metadata_path=random.choice(self.tilt_series_xmls)
-                )
-                tilt_series, images, pixel_size = (
-                    tilt_series_data.load_metadata_and_stack(downsample=self.downsample)
-                )
-                break
-            except (ValueError, OSError) as e:
-                if attempt < max_retries - 1:
-                    time.sleep(PAUSE_POLL_INTERVAL * (2**attempt))
-                elif self._tilt_series is not None:
-                    # Keep using the previously loaded data rather than crashing
-                    return
-                else:
-                    raise RuntimeError(
-                        f"Failed to load tilt-series after {max_retries} attempts"
-                    ) from e
+        tilt_series_data = TiltSeriesData(
+            xml_metadata_path=random.choice(self.tilt_series_xmls)
+        )
+        tilt_series, images, pixel_size = tilt_series_data.load_metadata_and_stack(
+            downsample=self.downsample,
+            retry_on_read_error=True,
+        )
         # run the preprocessing from warp for consistency
         images = preprocess_tilt_data(
             tilt_data=images,

--- a/src/miss_alignment/data/io.py
+++ b/src/miss_alignment/data/io.py
@@ -1,4 +1,5 @@
 import pickle
+import time
 import torch
 import mrcfile
 from pathlib import Path
@@ -21,11 +22,12 @@ class TiltSeriesData:
         return self.xml_metadata_path.stem
 
     def load_metadata_and_stack(
-        self, downsample=1
+        self, downsample=1, retry_on_read_error=False
     ) -> tuple[TiltSeries, torch.Tensor, float]:
         metadata, images, pixel_size = _load_metadata_and_stack(
             self.xml_metadata_path,
             downsample=downsample,
+            retry_on_read_error=retry_on_read_error,
         )
         return metadata, images, pixel_size
 
@@ -61,6 +63,7 @@ def _validate_tilt_series_dimensions(tilt_series: TiltSeries, path: Path) -> Non
 def _load_metadata_and_stack(
     metadata_path: Path,
     downsample: int = 1,
+    retry_on_read_error: bool = False,
 ) -> tuple[TiltSeries, torch.Tensor, float]:
     # load metadata
     tilt_series = TiltSeries(metadata_path)
@@ -68,10 +71,27 @@ def _load_metadata_and_stack(
 
     stack_path = tilt_series.tilt_stack_path
 
-    # load the data
-    with mrcfile.open(stack_path) as mrc:
-        images = torch.tensor(mrc.data)
-        stack_pixel_size = float(mrc.voxel_size.x)
+    if retry_on_read_error:
+        # Retry on transient short-read errors from the filesystem (e.g. GPFS).
+        # Multiple reconstruction workers may open the same file simultaneously,
+        # causing the filesystem to return fewer bytes than expected.
+        # Only ValueErrors whose message contains "read" indicate a short read;
+        # other ValueErrors (corrupt file, bad mode) are permanent and re-raised.
+        _max_retries = 5
+        for _attempt in range(_max_retries):
+            try:
+                with mrcfile.open(stack_path) as mrc:
+                    images = torch.tensor(mrc.data)
+                    stack_pixel_size = float(mrc.voxel_size.x)
+                break
+            except ValueError as e:
+                if "read" not in str(e) or _attempt == _max_retries - 1:
+                    raise
+                time.sleep(0.05 * (2**_attempt))
+    else:
+        with mrcfile.open(stack_path) as mrc:
+            images = torch.tensor(mrc.data)
+            stack_pixel_size = float(mrc.voxel_size.x)
 
     pixel_size = stack_pixel_size
     if downsample > 1:

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 import mrcfile
-import json
 from pathlib import Path
+from unittest.mock import patch
 
 from warpylib import TiltSeries
 from miss_alignment.data.io import TiltSeriesData
@@ -29,7 +29,6 @@ class TestTiltSeriesData:
     def test_initialization(self, tmp_path):
         """Test TiltSeriesData initialization with required parameters."""
         xml_path = tmp_path / "test.xml"
-        stack_path = tmp_path / "test.st"
 
         data = TiltSeriesData(
             xml_metadata_path=xml_path,
@@ -131,3 +130,86 @@ class TestTiltSeriesData:
         assert loaded_images.shape[0] == n_tilts
         assert loaded_images.shape[1] == 50
         assert loaded_images.shape[2] == 50
+
+
+class TestRetryOnReadError:
+    """Tests for the retry_on_read_error flag in load_metadata_and_stack."""
+
+    @pytest.fixture
+    def tilt_series_data(self, tmp_path):
+        xml_path = tmp_path / "test.xml"
+        n_tilts = 5
+        ts = TiltSeries(path=xml_path, n_tilts=n_tilts)
+        ts.angles = torch.linspace(-60, 60, n_tilts)
+        ts.image_dimensions_physical = torch.tensor([1000.0, 1000.0])
+        ts.volume_dimensions_physical = torch.tensor([1000.0, 1000.0, 1000.0])
+        ts.save_meta(xml_path)
+        Path(ts.tilt_stack_path).parent.mkdir(parents=True, exist_ok=True)
+        with mrcfile.new(ts.tilt_stack_path, overwrite=True) as mrc:
+            mrc.set_data(torch.randn(n_tilts, 50, 50).numpy())
+            mrc.voxel_size = 10.0
+        return TiltSeriesData(xml_metadata_path=xml_path)
+
+    def test_transient_error_retried_and_succeeds(self, tilt_series_data):
+        """retry_on_read_error=True retries a short-read ValueError until success."""
+        real_open = mrcfile.open
+        call_count = 0
+
+        def fail_twice_then_succeed(path, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("Couldn't read enough bytes for MRC header")
+            return real_open(path, **kwargs)
+
+        with patch(
+            "miss_alignment.data.io.mrcfile.open", side_effect=fail_twice_then_succeed
+        ):
+            with patch("miss_alignment.data.io.time.sleep"):
+                tilt_series_data.load_metadata_and_stack(retry_on_read_error=True)
+
+        assert call_count == 3
+
+    def test_transient_error_propagates_without_flag(self, tilt_series_data):
+        """retry_on_read_error=False (default) propagates the error immediately."""
+        with patch(
+            "miss_alignment.data.io.mrcfile.open",
+            side_effect=ValueError("Couldn't read enough bytes for MRC header"),
+        ):
+            with pytest.raises(ValueError, match="read enough bytes"):
+                tilt_series_data.load_metadata_and_stack(retry_on_read_error=False)
+
+    def test_permanent_error_not_retried(self, tilt_series_data):
+        """Permanent errors (no 'read' in message) are not retried."""
+        call_count = 0
+
+        def permanent_error(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError(
+                "Map ID string not found - not an MRC file, or file is corrupt"
+            )
+
+        with patch("miss_alignment.data.io.mrcfile.open", side_effect=permanent_error):
+            with pytest.raises(ValueError, match="Map ID"):
+                tilt_series_data.load_metadata_and_stack(retry_on_read_error=True)
+
+        assert call_count == 1
+
+    def test_all_retries_exhausted_raises(self, tilt_series_data):
+        """After 5 failed attempts the error propagates."""
+        call_count = 0
+
+        def always_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError(
+                "Expected 1024 bytes in data block but could only read 512"
+            )
+
+        with patch("miss_alignment.data.io.mrcfile.open", side_effect=always_fail):
+            with patch("miss_alignment.data.io.time.sleep"):
+                with pytest.raises(ValueError, match="could only read"):
+                    tilt_series_data.load_metadata_and_stack(retry_on_read_error=True)
+
+        assert call_count == 5


### PR DESCRIPTION
Closes #92 

On parallel filesystems (GPFS/NFS), concurrent open() calls on the same MRC file can return a short read, raising ValueError from mrcfile. Adds exponential-backoff retry (up to 5 attempts) in TiltSeriesFetcher._load_next(). If retries are exhausted but the worker already has a loaded tilt-series, it reuses that data rather than crashing the worker process.