### PR TITLE
perf: enable cudnn.benchmark and disable DDP find_unused_parameters

### DIFF
--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -207,8 +207,17 @@ def train_miss_align(
         # Set up trainer with parameters from config
         # Use DDP strategy for multi-GPU training with extended timeout
         # Default is 30 min, but alignment can take much longer while other ranks wait
+        # find_unused_parameters=False tells DDP to skip the per-step scan for
+        # parameters that didn't receive gradients before all-reduce. The model
+        # variants here (Compact3DConvNet etc.) are straight feed-forward, so
+        # every parameter contributes to the loss on every step; the scan is
+        # pure overhead. Disabling it is the Lightning-recommended default for
+        # such models.
         strategy = (
-            DDPStrategy(timeout=timedelta(hours=ddp_timeout_hours))
+            DDPStrategy(
+                timeout=timedelta(hours=ddp_timeout_hours),
+                find_unused_parameters=False,
+            )
             if len(devices_training) > 1
             else "auto"
         )
@@ -226,6 +235,12 @@ def train_miss_align(
             num_sanity_val_steps=0,
             callbacks=[early_stopping, checkpoint_callback, progress_bar],
             precision="16-mixed",  # Enable automatic mixed precision
+            # cudnn.benchmark picks the fastest conv algorithm per input shape
+            # and caches it. Inputs here are always patch_size^3 cubes, so the
+            # shape is constant after the first batch and the cached choice is
+            # reused for the rest of training. Net: a few-batch warmup then
+            # measurably faster conv-heavy steps on Ampere+ hardware.
+            benchmark=True,
         )
 
         # Initialize model with parameters from config

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -207,16 +207,10 @@ def train_miss_align(
         # Set up trainer with parameters from config
         # Use DDP strategy for multi-GPU training with extended timeout
         # Default is 30 min, but alignment can take much longer while other ranks wait
-        # find_unused_parameters=False tells DDP to skip the per-step scan for
-        # parameters that didn't receive gradients before all-reduce. The model
-        # variants here (Compact3DConvNet etc.) are straight feed-forward, so
-        # every parameter contributes to the loss on every step; the scan is
-        # pure overhead. Disabling it is the Lightning-recommended default for
-        # such models.
         strategy = (
             DDPStrategy(
                 timeout=timedelta(hours=ddp_timeout_hours),
-                find_unused_parameters=False,
+                find_unused_parameters=False,  # feed-forward model, no unused params
             )
             if len(devices_training) > 1
             else "auto"
@@ -235,12 +229,7 @@ def train_miss_align(
             num_sanity_val_steps=0,
             callbacks=[early_stopping, checkpoint_callback, progress_bar],
             precision="16-mixed",  # Enable automatic mixed precision
-            # cudnn.benchmark picks the fastest conv algorithm per input shape
-            # and caches it. Inputs here are always patch_size^3 cubes, so the
-            # shape is constant after the first batch and the cached choice is
-            # reused for the rest of training. Net: a few-batch warmup then
-            # measurably faster conv-heavy steps on Ampere+ hardware.
-            benchmark=True,
+            benchmark=True,  # cuDNN caches fastest conv algo for fixed input shape
         )
 
         # Initialize model with parameters from config


### PR DESCRIPTION
## Summary

Two zero-risk Lightning-hygiene knobs that should be on by default for this training loop. Both are pure performance, no behaviour change, no API change.

## 1. `Trainer(benchmark=True)`

The model variants in `models/_compact.py` and `_resnet.py` are 3D-conv-heavy networks. The input shape is always `(batch, 1, patch_size, patch_size, patch_size)`, constant for the entire run. cuDNN can pick the fastest algorithm per Conv3d layer for that constant shape on the first batch and cache it; without `benchmark=True` it uses a heuristic which is often slower for the actual shape.

Cost: a few-batch warmup as cuDNN tries algorithms.
Benefit: measurable speedup on the rest of training (in my real-data runs on a typical 4-tomo set, conv-heavy training steps were noticeably faster after warmup; exact gain depends on the GPU/cudnn version).

## 2. `DDPStrategy(find_unused_parameters=False)`

`find_unused_parameters=True` is PyTorch DDP's default and scans the autograd graph every backward pass for parameters that didn't receive a gradient, so it can skip them in the all-reduce. This is needed only when some parameters might be conditionally unused (gated experts, dropout-as-routing, etc.).

The MissAlignment models are all straight feed-forward CNNs — every parameter contributes to the loss on every step. The scan is pure overhead. Setting `find_unused_parameters=False` is the Lightning-recommended default for such models.

## Why open this together

Both knobs are roughly the same kind of change (Trainer/Strategy defaults that should be on for a well-defined feed-forward model with constant input shape) and the diff is small. Happy to split into two PRs if preferred.

## Test plan
- [x] `pytest tests/` → 153 passed, 2 skipped (matches main).
- [x] No API change: existing callers see no signature or behaviour difference.
- [x] Smoke-ran a multi-iteration training on real cryo-EM tilt-series with both flags on; results match the unmodified version qualitatively (convergence pattern, loss values in the same range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)