### PR TITLE
Refactor/scoped ddp training

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,21 +311,15 @@ tilt_series.tilt_axis_offset_x += shifts_angstrom[:, 1]
 
 ## Working on GitHub Issues
 
-1. Read the issue at `https://github.com/warpem/miss-alignment/issues/<number>` using `gh issue view <number>`
-2. Create a branch named after the issue: `git checkout -b fix/<short-description>` or `feat/<short-description>`
-3. If possible, write a failing test that reproduces the issue before touching the implementation
-4. Fix the code until the test passes
+- Read the issue with `gh issue view <number>` (repo: `warpem/miss-alignment`)
+- Branch named after the issue: `fix/<short-description>` or `feat/<short-description>`
+- Where possible, reproduce the issue with a failing test before touching the implementation
 
 ## Development Practices
 
-When working on this codebase, if you encounter potential bugs or implementation issues:
-
-1. **Report the issue**: Clearly explain what you found and why it appears to be a bug
-2. **Suggest a fix**: Provide a proposed solution with reasoning
-3. **Implement if appropriate**: For clear bugs (e.g., missing conversions, type inconsistencies, logic errors), implement the fix
-4. **Let the maintainer decide if unsure**: The maintainer will evaluate whether it's truly a bug or was intentional design
-
-**Don't just write tests to conform to buggy behavior** - if the implementation looks wrong, report it and suggest the fix rather than masking it with adjusted test expectations.
+This is actively-used research software (preprint published, real users), so be
+conservative with breaking changes. When you spot a likely bug, report it with a proposed
+fix and let the maintainer decide — don't silently conform tests to buggy behavior.
 
 ## File Organization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,16 @@ python -m pip install -e .[dev,test]
      - `(3, 3, 41)`: 2D warping field per image
      - `(3, 3, 2, 10)`: 3D volume warp grid
 
-4. **`train.py`** - Iterative training loop
-   - Alternates between model training and tilt-series alignment
-   - Each iteration: train model → align tilt-series → use aligned data for next iteration
+4. **`train.py`** - Iterative training loop ("macro-iterations")
+   - Runs a sequence of **macro-iterations**, each containing two phases: (1) a model
+     training phase and (2) a tilt-series alignment phase. The aligned output of one
+     macro-iteration is the input to the next.
+   - **`trainer.fit()` is therefore called once per macro-iteration** (i.e. multiple
+     times per run), each time with a long *single-process* alignment phase afterwards.
+     This is the central structural constraint of the codebase and a frequent source of
+     confusion: it breaks Lightning's "the script == one training run" assumption, which
+     is why plain DDP cannot be used naively (see **Multi-GPU support** under Important
+     Patterns for how this is handled).
    - Configured via YAML file (see `config_template.yaml`)
 
 ### Important Dependencies on External Libraries
@@ -341,6 +348,18 @@ miss-alignment/
 
 1. **Configuration-driven**: All training parameters are specified in YAML files
 2. **Iterative refinement**: Training alternates between model training and alignment steps
-3. **Multi-GPU support**: Both training and alignment can use multiple GPUs
+3. **Multi-GPU support**: Both training and alignment can use multiple GPUs. Because
+   `trainer.fit()` is called once per macro-iteration with a long single-process
+   alignment phase between calls (see `train.py` above), DDP cannot wrap the whole
+   program: the default DDP launcher re-runs the entire script per GPU, which would leave
+   every non-rank-0 rank idle through each alignment phase. Instead, **each
+   macro-iteration's training phase is scoped to its own DDP process group**: `train.py`
+   launches one `_training_worker` per training device via `torch.multiprocessing.spawn`,
+   acting as its own launcher (exports `LOCAL_RANK` etc.) so Lightning attaches instead
+   of re-spawning. After the spawn joins, the main process is single-process again and
+   runs alignment directly — no idle ranks, no barriers. Single-GPU runs the worker
+   in-process with no DDP. The `DDPStrategy` pins
+   `cluster_environment=LightningEnvironment()` so SLURM auto-detection cannot hijack the
+   spawned ranks; do not remove this (see `docs/usage.md` SLURM notes). Single-node only.
 4. **Synthetic data augmentation**: Training uses procedurally generated alignment errors
 5. **Pool-based data loading**: Pre-computed reconstructions in a pool improve training throughput

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ miss-alignment is a deep learning package for tilt-series alignment in cryo-elec
 
 ### Scientific publication
 
-This software is a research project with a preprint publication on biorxiv. People are actively using it and it is supposed to be a software solution, so we need to carefully consider breaking changes.
+This software is published (preprint on biorxiv) and deployed in multiple labs. Treat it as a stable, production tool: avoid unnecessary breaking changes and consider backward compatibility carefully.
 
 ## Environment Setup
 
@@ -317,9 +317,9 @@ tilt_series.tilt_axis_offset_x += shifts_angstrom[:, 1]
 
 ## Development Practices
 
-This is actively-used research software (preprint published, real users), so be
-conservative with breaking changes. When you spot a likely bug, report it with a proposed
-fix and let the maintainer decide — don't silently conform tests to buggy behavior.
+This software is deployed across multiple labs, so treat it as stable and be conservative
+with breaking changes. When you spot a likely bug, report it with a proposed fix and let
+the maintainer decide — don't silently conform tests to buggy behavior.
 
 ## File Organization
 

--- a/docs/config_template.yaml
+++ b/docs/config_template.yaml
@@ -17,7 +17,7 @@ general:
 model_training:
   # used to initialize model weights
   model_architecture: 'default'
-  model_checkpoint: null
+  model_checkpoint: null  # only used as initialization for iteration 0
   loss_margin: 0.5
   learning_rate: 1.0e-3
   # Set to zero to disable weight decay (i.e. the AdamW optimizer)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -112,3 +112,10 @@ miss-alignment \
   including from the spawned reconstruction workers. PyTorch Lightning's INFO startup
   banners stay suppressed regardless of this setting. This controls text logging only;
   the tqdm progress bars are always shown (they write to stdout independently).
+
+- **`torch.compile` workers**: each training rank runs its own TorchInductor compile
+  pool (default `min(32, n_cpus)` processes *per rank*), so multi-GPU runs can spawn a
+  lot of idle compile workers. miss-alignment defaults `TORCHINDUCTOR_COMPILE_THREADS`
+  to `available_cpus // n_training_devices` (respecting the SLURM `--cpus-per-task`
+  cpuset via `sched_getaffinity`). Override it by exporting `TORCHINDUCTOR_COMPILE_THREADS`
+  yourself.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,10 +44,11 @@ After miss-alignment finishes, update the CTF parameters in WarpTools (`ts_ctf`)
 
 ### Single-node requirement
 
-miss-alignment uses `LOCAL_RANK` (set by Lightning's process launcher) to identify
-the main process. This means **all GPUs must be on a single node**. Multi-node
-distributed training is not supported. Your submission script must request all GPUs
-on one node.
+miss-alignment launches its own per-GPU training processes (via
+`torch.multiprocessing.spawn`) and exports `LOCAL_RANK` so Lightning attaches to that
+process group instead of starting its own. These processes rendezvous over
+`localhost`, so **all GPUs must be on a single node**. Multi-node distributed training
+is not supported. Your submission script must request all GPUs on one node.
 
 ### Example submission script
 
@@ -85,16 +86,19 @@ miss-alignment \
 
 | Setting | Why |
 |---|---|
-| `--ntasks=1` | Required. miss-alignment manages its own subprocesses; SLURM should only start one task. |
+| `--ntasks=1` | Required. miss-alignment is its own launcher — it spawns one training process per `--training-devices` entry. SLURM must start exactly **one** task. Do **not** use `srun --ntasks=N`, or SLURM will start N copies of the program that each spawn their own workers. |
 | `--nodes=1` | Required. All GPUs must be on a single node (see above). |
 | `--cpus-per-task` | Set to `len(--reconstruction-devices) + n_training_devices × dataloaders_per_trainer`. Each reconstruction worker and each DataLoader worker (spawned per DDP rank) needs a CPU. For the example above: 6 + 2×5 = 16. |
 | `--gres=gpu:N` | Request all GPUs you intend to use for training + reconstruction. |
 
 ### Notes
 
-- **Lightning srun warning**: Lightning may warn that `srun` is available but not used.
-  This warning can be safely ignored — do not prepend `srun` to the command, as that
-  would conflict with miss-alignment's own process management.
+- **Do not launch with `srun --ntasks=N`**: miss-alignment spawns its own per-GPU
+  training processes, so the job must run as a single task (`--ntasks=1`). Launching
+  multiple tasks would start independent copies that each spawn their own workers. Run
+  the command directly — no `srun` prefix is needed. The cluster environment is pinned
+  to Lightning's `LightningEnvironment`, so SLURM's `SLURM_PROCID`/`SLURM_NTASKS` are
+  ignored and no "srun available but not used" warning is emitted.
 
 - **Temporary storage**: The reconstruction pool is written to `$TMPDIR` (defaulting to
   `/tmp`). On clusters where `/tmp` is shared or small, set `TMPDIR` to a local scratch

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -110,8 +110,5 @@ miss-alignment \
 - **Log verbosity**: miss-alignment logs at `WARNING` by default. Set
   `MISS_ALIGNMENT_LOG_LEVEL=DEBUG` (or `INFO`) to see its own diagnostic output,
   including from the spawned reconstruction workers. PyTorch Lightning's INFO startup
-  banners stay suppressed regardless of this setting.
-
-- **Progress bars**: The training and alignment progress bars show when stdout is an
-  interactive terminal and switch off automatically when output is redirected to a file
-  or pipe (e.g. a SLURM `--output` log), so captured logs stay clean.
+  banners stay suppressed regardless of this setting. This controls text logging only;
+  the tqdm progress bars are always shown (they write to stdout independently).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,3 +106,12 @@ miss-alignment \
 
 - **Resuming**: If a job times out mid-run, restart with `--start-at-iteration N` where
   `N` is the last completed iteration (counting from 0).
+
+- **Log verbosity**: miss-alignment logs at `WARNING` by default. Set
+  `MISS_ALIGNMENT_LOG_LEVEL=DEBUG` (or `INFO`) to see its own diagnostic output,
+  including from the spawned reconstruction workers. PyTorch Lightning's INFO startup
+  banners stay suppressed regardless of this setting.
+
+- **Progress bars**: The training and alignment progress bars show when stdout is an
+  interactive terminal and switch off automatically when output is redirected to a file
+  or pipe (e.g. a SLURM `--output` log), so captured logs stay clean.

--- a/src/miss_alignment/_parallel.py
+++ b/src/miss_alignment/_parallel.py
@@ -56,7 +56,6 @@ def run_device_pool(
             total=len(jobs),
             desc=desc,
             file=sys.stdout,
-            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
         )
         while len(results) < len(jobs):
             while not result_queue.empty():

--- a/src/miss_alignment/_parallel.py
+++ b/src/miss_alignment/_parallel.py
@@ -1,0 +1,81 @@
+"""Shared one-process-per-GPU work-queue helper.
+
+Mirrors the scheme used by ``alignment.run_alignment_parallel``: start exactly
+one worker process per unique device, feed all jobs through a shared queue, and
+let each worker pull jobs until the queue is empty. This binds a device to a
+*process* (deterministic, one job per GPU at a time) instead of to a task index,
+and uses every available device rather than a fixed process count.
+"""
+
+import multiprocessing as mp
+import sys
+import time
+from collections.abc import Callable
+from typing import Any
+
+import tqdm
+
+
+def run_device_pool(
+    jobs: list[Any],
+    runner: Callable,
+    runner_args: tuple,
+    devices: list[int] | None,
+    desc: str,
+) -> list[Any]:
+    """Run ``jobs`` across one worker process per unique device.
+
+    Each worker runs ``runner(device, task_queue, result_queue, *runner_args)``,
+    pulling jobs off ``task_queue`` until empty and putting one result on
+    ``result_queue`` per finished job. One process is started per unique entry in
+    ``devices`` (or a single default-device process when ``devices`` is falsy).
+
+    Returns the list of results collected from the workers. Raises ``RuntimeError``
+    if any worker exits with a non-zero code (all workers are then terminated).
+    """
+    ctx = mp.get_context("spawn")
+    device_slots = sorted(set(devices)) if devices else [None]
+
+    with ctx.Manager() as manager:
+        task_queue = manager.Queue()
+        result_queue = manager.Queue()
+        for job in jobs:
+            task_queue.put_nowait(job)
+
+        procs = [
+            ctx.Process(
+                target=runner,
+                args=(device, task_queue, result_queue, *runner_args),
+            )
+            for device in device_slots
+        ]
+        [p.start() for p in procs]
+
+        results: list[Any] = []
+        pbar = tqdm.tqdm(
+            total=len(jobs),
+            desc=desc,
+            file=sys.stdout,
+            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
+        )
+        while len(results) < len(jobs):
+            while not result_queue.empty():
+                results.append(result_queue.get_nowait())
+                pbar.update(1)
+
+            for p in procs:
+                # a worker that died with a non-zero exit code means a job failed;
+                # tear everything down rather than hang waiting for its result
+                if not p.is_alive() and p.exitcode != 0:
+                    [x.terminate() for x in procs]
+                    pbar.close()
+                    raise RuntimeError(
+                        f"A worker process for '{desc}' stopped unexpectedly."
+                    )
+
+            time.sleep(0.1)
+
+        pbar.close()
+        [p.join() for p in procs]
+
+    return results

--- a/src/miss_alignment/_parallel.py
+++ b/src/miss_alignment/_parallel.py
@@ -66,7 +66,10 @@ def run_device_pool(
                 # a worker that died with a non-zero exit code means a job failed;
                 # tear everything down rather than hang waiting for its result
                 if not p.is_alive() and p.exitcode != 0:
-                    [x.terminate() for x in procs]
+                    for x in procs:
+                        x.terminate()
+                    for x in procs:
+                        x.join(timeout=5.0)
                     pbar.close()
                     raise RuntimeError(
                         f"A worker process for '{desc}' stopped unexpectedly."

--- a/src/miss_alignment/alignment/parallel.py
+++ b/src/miss_alignment/alignment/parallel.py
@@ -127,12 +127,7 @@ def run_alignment_parallel(
         ]
         [p.start() for p in procs]
 
-        pbar = tqdm.tqdm(
-            total=len(jobs),
-            desc="tilt-series alignment",
-            file=sys.stdout,
-            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
-        )
+        pbar = tqdm.tqdm(total=len(jobs), desc="tilt-series alignment", file=sys.stdout)
         while True:
             while not result_queue.empty():
                 results.append(result_queue.get_nowait())

--- a/src/miss_alignment/alignment/parallel.py
+++ b/src/miss_alignment/alignment/parallel.py
@@ -1,17 +1,14 @@
 import queue
-import multiprocessing as mp
-import sys
-import time
 import torch
-import tqdm
 from multiprocessing.managers import BaseProxy
 from pathlib import Path
 
+from .._parallel import run_device_pool
 from .tilt_series import evaluate_tilt_series
 
 
 def gpu_runner(
-    device: str,
+    device: int,
     task_queue: BaseProxy,
     result_queue: BaseProxy,
 ) -> None:
@@ -22,7 +19,7 @@ def gpu_runner(
 
     Parameters
     ----------
-    device: str
+    device: int
         a GPU index to assign to the runner
     task_queue: mp.managers.BaseProxy
         shared queue from multiprocessing with jobs to run
@@ -30,12 +27,13 @@ def gpu_runner(
         shared queue from multiprocessing for finished jobs
     """
     torch.set_num_threads(1)
+    cuda_device = f"cuda:{device}"
     while True:
         try:
             task_parameters = task_queue.get_nowait()
             tilt_series_path, loss_values = evaluate_tilt_series(
                 **task_parameters,
-                device=device,
+                device=cuda_device,
             )
             # place the name and final loss of the finished tilt_series
             final_loss = float(loss_values[-1]) if loss_values else None
@@ -82,76 +80,29 @@ def run_alignment_parallel(
     dict[str, float]
         Dictionary mapping tilt-series names to their final loss values.
     """
-    jobs = []
-    for i, tilt_series in enumerate(tilt_series_list):
-        jobs.append(
-            {
-                "model_checkpoint_path": model_checkpoint,
-                "tilt_series_path": tilt_series,
-                "output_directory": output_directory,
-                "setting": setting,
-                "patch_size": patch_size,
-                "patch_overlap": patch_overlap,
-                "batch_size": batch_size,
-                "apply_ctf": apply_ctf,
-                "downsample": downsample,
-            }
-        )
+    jobs = [
+        {
+            "model_checkpoint_path": model_checkpoint,
+            "tilt_series_path": tilt_series,
+            "output_directory": output_directory,
+            "setting": setting,
+            "patch_size": patch_size,
+            "patch_overlap": patch_overlap,
+            "batch_size": batch_size,
+            "apply_ctf": apply_ctf,
+            "downsample": downsample,
+        }
+        for tilt_series in tilt_series_list
+    ]
 
-    results = []
-    # Use explicit spawn context to avoid CUDA issues with fork
-    ctx = mp.get_context("spawn")
-    with ctx.Manager() as manager:
-        task_queue = (
-            manager.Queue()
-        )  # the list of tasks where processes can get there next task from
-        result_queue = (
-            manager.Queue()
-        )  # this will accumulate results from the processes
-
-        [task_queue.put_nowait(j) for j in jobs]  # put all tasks
-
-        # set the processes and start them!
-        # if a device occurs multiple times in devices_list,
-        # use it only once to keep memory footprint deterministic per GPU
-        procs = [
-            ctx.Process(
-                target=gpu_runner,
-                args=(
-                    "cuda:" + str(g),
-                    task_queue,
-                    result_queue,
-                ),
-            )
-            for g in set(devices_list)
-        ]
-        [p.start() for p in procs]
-
-        pbar = tqdm.tqdm(total=len(jobs), desc="tilt-series alignment", file=sys.stdout)
-        while True:
-            while not result_queue.empty():
-                results.append(result_queue.get_nowait())
-                pbar.update(1)
-
-            if len(results) == len(jobs):
-                # its done if all the results from the spawn were send back
-                break
-
-            for p in procs:
-                # if one of the processes is no longer alive and has a failed exit
-                # we should error
-                if not p.is_alive() and p.exitcode != 0:  # to prevent a deadlock
-                    [
-                        x.terminate() for x in procs
-                    ]  # kill all spawned processes if something broke
-                    raise RuntimeError(
-                        "One or more of the processes stopped unexpectedly."
-                    )
-
-            time.sleep(0.1)
-        pbar.close()
-
-        [p.join() for p in procs]
+    # one worker process per unique GPU, each pulling jobs from a shared queue
+    results = run_device_pool(
+        jobs=jobs,
+        runner=gpu_runner,
+        runner_args=(),
+        devices=devices_list,
+        desc="tilt-series alignment",
+    )
 
     # Convert results to dictionary of losses
     losses = {result["name"]: result["final_loss"] for result in results}

--- a/src/miss_alignment/alignment/parallel.py
+++ b/src/miss_alignment/alignment/parallel.py
@@ -101,7 +101,7 @@ def run_alignment_parallel(
         runner=gpu_runner,
         runner_args=(),
         devices=devices_list,
-        desc="tilt-series alignment",
+        desc="Tilt series alignment",
     )
 
     # Convert results to dictionary of losses

--- a/src/miss_alignment/alignment/parallel.py
+++ b/src/miss_alignment/alignment/parallel.py
@@ -127,7 +127,12 @@ def run_alignment_parallel(
         ]
         [p.start() for p in procs]
 
-        pbar = tqdm.tqdm(total=len(jobs), desc="tilt-series alignment", file=sys.stdout)
+        pbar = tqdm.tqdm(
+            total=len(jobs),
+            desc="tilt-series alignment",
+            file=sys.stdout,
+            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
+        )
         while True:
             while not result_queue.empty():
                 results.append(result_queue.get_nowait())

--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -1,3 +1,4 @@
+import logging
 import multiprocessing as mp
 import random
 import tempfile
@@ -17,6 +18,8 @@ from dataclasses import dataclass
 from miss_alignment.data.io import TiltSeriesData
 from miss_alignment.data.shift_generation import project_shifts_3d_to_2d
 from ._augmentation import MIRROR_COMBINATIONS, apply_mirror
+
+logger = logging.getLogger(__name__)
 
 # augmentation parameter
 MAX_ANGLE_DEGREES = 10.0
@@ -151,7 +154,7 @@ def reconstruction_worker(
     """
     torch.set_num_threads(1)
 
-    print(
+    logger.debug(
         f"Reconstruction worker {worker_id} starting "
         f"(cycling through {n_partitions} partitions, {partition_size} files each)"
     )
@@ -203,7 +206,9 @@ def reconstruction_worker(
                         # stop_event here because the outer loop condition
                         # is never reached while we're stuck in this loop.
                         if stop_event.is_set():
-                            print(f"Reconstruction worker {worker_id} shutting down")
+                            logger.debug(
+                                f"Reconstruction worker {worker_id} shutting down"
+                            )
                             return
                         time.sleep(PAUSE_POLL_INTERVAL)
                         partitions_checked = 0
@@ -236,7 +241,7 @@ def reconstruction_worker(
                 # Move to next partition (round-robin)
                 current_partition = (current_partition + 1) % n_partitions
 
-    print(f"Reconstruction worker {worker_id} shutting down")
+    logger.debug(f"Reconstruction worker {worker_id} shutting down")
 
 
 def sample_positions(

--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 from miss_alignment.data.io import TiltSeriesData
 from miss_alignment.data.shift_generation import project_shifts_3d_to_2d
+from miss_alignment.utils import configure_logging
 from ._augmentation import MIRROR_COMBINATIONS, apply_mirror
 
 logger = logging.getLogger(__name__)
@@ -153,6 +154,11 @@ def reconstruction_worker(
         Device to use
     """
     torch.set_num_threads(1)
+
+    # Spawned process: re-apply logging config from MISS_ALIGNMENT_LOG_LEVEL so
+    # these debug lines are reachable (runtime logging config does not survive
+    # the spawn boundary; the env var does).
+    configure_logging()
 
     logger.debug(
         f"Reconstruction worker {worker_id} starting "

--- a/src/miss_alignment/data/training_datamodule.py
+++ b/src/miss_alignment/data/training_datamodule.py
@@ -242,6 +242,9 @@ class MissAlignmentDataModule(pl.LightningDataModule):
                         "tilt_series_refresh_rate": 10,
                         "device": self.reconstruction_devices[worker_id],
                     },
+                    # daemon so a hard crash of the parent (before teardown runs)
+                    # takes the reconstruction workers down with it
+                    daemon=True,
                 )
                 p.start()
                 self.pool_processes.append(p)
@@ -288,7 +291,10 @@ class MissAlignmentDataModule(pl.LightningDataModule):
                 for p in self.pool_processes:
                     p.join(timeout=5.0)
                     if p.is_alive():
-                        p.terminate()
+                        p.terminate()  # SIGTERM
+                        p.join(timeout=5.0)
+                    if p.is_alive():
+                        p.kill()  # SIGKILL if it ignored SIGTERM
                         p.join()
 
             if self.pool_dir and self.pool_dir.exists():

--- a/src/miss_alignment/data/training_datamodule.py
+++ b/src/miss_alignment/data/training_datamodule.py
@@ -1,5 +1,6 @@
 # standard libraries
 import hashlib
+import logging
 import multiprocessing as mp
 import shutil
 import tempfile
@@ -15,6 +16,8 @@ from torch.utils.data import DataLoader
 from ._reconstruction_worker import reconstruction_worker
 from .training_dataset import ReconstructionPoolDataset
 from ..utils import is_rank_zero
+
+logger = logging.getLogger(__name__)
 
 
 # Default pool size
@@ -279,7 +282,7 @@ class MissAlignmentDataModule(pl.LightningDataModule):
         # Only perform full teardown on rank 0 (where workers were spawned)
         if is_rank_zero():
             if self.stop_event:
-                print("Stopping reconstruction workers...")
+                logger.debug("Stopping reconstruction workers...")
                 self.stop_event.set()
 
                 for p in self.pool_processes:
@@ -290,9 +293,9 @@ class MissAlignmentDataModule(pl.LightningDataModule):
 
             if self.pool_dir and self.pool_dir.exists():
                 shutil.rmtree(self.pool_dir)
-                print(f"Cleaned up pool directory: {self.pool_dir}")
+                logger.debug(f"Cleaned up pool directory: {self.pool_dir}")
 
-            print("Cleanup complete")
+            logger.debug("Cleanup complete")
 
         # Reset state for potential reuse (all ranks)
         self._workers_spawned = False

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -402,7 +402,6 @@ class MAProgressBar(Callback):
             dynamic_ncols=True,
             leave=True,
             file=sys.stdout,
-            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
         )
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -402,6 +402,7 @@ class MAProgressBar(Callback):
             dynamic_ncols=True,
             leave=True,
             file=sys.stdout,
+            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
         )
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):

--- a/src/miss_alignment/prepare_stacks.py
+++ b/src/miss_alignment/prepare_stacks.py
@@ -4,15 +4,14 @@ This module provides functionality to load raw tilt images and create
 preprocessed tilt stacks ready for training.
 """
 
-import multiprocessing as mp
-import sys
-from concurrent.futures import ProcessPoolExecutor
+import queue
 from pathlib import Path
 
 import mrcfile
-from tqdm import tqdm
 from warpylib import TiltSeries
 from warpylib.movie import Movie
+
+from ._parallel import run_device_pool
 
 
 def _get_original_pixel_size(tilt_series: TiltSeries) -> float:
@@ -107,10 +106,28 @@ def _prepare_single_tilt_series(
     )
 
 
+def _prepare_stacks_runner(
+    device: int | None,
+    task_queue,
+    result_queue,
+    desired_pixel_size: float,
+) -> None:
+    """Pull tilt-series off the queue and prepare them on a single device."""
+    import torch
+
+    torch.set_num_threads(1)
+    while True:
+        try:
+            xml_path = task_queue.get_nowait()
+        except queue.Empty:
+            break
+        _prepare_single_tilt_series(xml_path, desired_pixel_size, device)
+        result_queue.put_nowait(xml_path.stem)
+
+
 def prepare_stacks_parallel(
     training_directory: Path,
     desired_pixel_size: float,
-    n_processes: int = 4,
     devices: list[int] | None = None,
 ) -> None:
     """Prepare tilt stacks for all tilt series in the training directory.
@@ -124,10 +141,9 @@ def prepare_stacks_parallel(
         Directory containing tilt series XML files.
     desired_pixel_size : float
         Desired pixel size in Angstroms for the output stacks.
-    n_processes : int
-        Number of parallel processes to use. Default is 4.
     devices : list[int] | None
-        List of CUDA device indices to distribute work across. If None, uses CPU.
+        CUDA device indices to distribute work across (one worker process per
+        unique device). If None, a single default-device worker is used.
 
     Raises
     ------
@@ -146,26 +162,12 @@ def prepare_stacks_parallel(
         f"Preparing stacks for {len(xml_files)} tilt series at {desired_pixel_size} Å"
     )
 
-    # Use explicit spawn context to avoid CUDA issues with fork
-    ctx = mp.get_context("spawn")
-    with ProcessPoolExecutor(max_workers=n_processes, mp_context=ctx) as executor:
-        # Submit all tasks with round-robin device assignment
-        futures = []
-        for i, xml_path in enumerate(xml_files):
-            device = devices[i % len(devices)] if devices else None
-            future = executor.submit(
-                _prepare_single_tilt_series, xml_path, desired_pixel_size, device
-            )
-            futures.append(future)
-
-        for future in tqdm(
-            futures,
-            desc="Preparing stacks",
-            unit="tilt series",
-            file=sys.stdout,
-            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
-        ):
-            # This will raise any exception that occurred in the worker
-            future.result()
+    run_device_pool(
+        jobs=xml_files,
+        runner=_prepare_stacks_runner,
+        runner_args=(desired_pixel_size,),
+        devices=devices,
+        desc="Preparing stacks",
+    )
 
     print(f"Successfully prepared stacks for {len(xml_files)} tilt series")

--- a/src/miss_alignment/prepare_stacks.py
+++ b/src/miss_alignment/prepare_stacks.py
@@ -159,7 +159,11 @@ def prepare_stacks_parallel(
             futures.append(future)
 
         for future in tqdm(
-            futures, desc="Preparing stacks", unit="tilt series", file=sys.stdout
+            futures,
+            desc="Preparing stacks",
+            unit="tilt series",
+            file=sys.stdout,
+            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
         ):
             # This will raise any exception that occurred in the worker
             future.result()

--- a/src/miss_alignment/preprocessing.py
+++ b/src/miss_alignment/preprocessing.py
@@ -1,12 +1,9 @@
 """Preprocessing utilities for tilt-series alignment."""
 
-import multiprocessing as mp
-import sys
-from concurrent.futures import ProcessPoolExecutor
+import queue
 from pathlib import Path
 
-from tqdm import tqdm
-
+from ._parallel import run_device_pool
 from .data.io import TiltSeriesData
 
 
@@ -77,10 +74,31 @@ def _run_cross_correlation_single(
     return float(pretilt)
 
 
+def _cross_correlation_runner(
+    device: int | None,
+    task_queue,
+    result_queue,
+    lowpass_cutoff: float,
+    pretilt_search_range: tuple[float, float],
+) -> None:
+    """Pull tilt-series off the queue and align them on a single device."""
+    import torch
+
+    torch.set_num_threads(1)
+    while True:
+        try:
+            xml_file = task_queue.get_nowait()
+        except queue.Empty:
+            break
+        _run_cross_correlation_single(
+            xml_file, device, lowpass_cutoff, pretilt_search_range
+        )
+        result_queue.put_nowait(xml_file.stem)
+
+
 def run_cross_correlation_alignment_parallel(
     training_directory: Path,
     devices: list[int] | None = None,
-    n_processes: int = 4,
     lowpass_cutoff: float = 0.25,
     pretilt_search_range: tuple[float, float] = (-30.0, 30.0),
 ) -> None:
@@ -96,10 +114,8 @@ def run_cross_correlation_alignment_parallel(
     training_directory : Path
         Directory containing XML metadata files for tilt-series.
     devices : list[int] | None, optional
-        List of CUDA device indices to distribute work across. If None, uses
-        default device assignment.
-    n_processes : int, optional
-        Number of parallel processes to use (default: 4).
+        CUDA device indices to distribute work across (one worker process per
+        unique device). If None, a single default-device worker is used.
     lowpass_cutoff : float, optional
         Low-pass filter cutoff frequency (default: 0.25).
     pretilt_search_range : tuple[float, float], optional
@@ -117,36 +133,17 @@ def run_cross_correlation_alignment_parallel(
         f"{pretilt_search_range[0]}° to {pretilt_search_range[1]}°"
     )
     print(f"  Low-pass cutoff: {lowpass_cutoff}")
-    print(f"  Using {n_processes} parallel processes")
     if devices:
         print(f"  Distributing across devices: {devices}\n")
     else:
         print("  Using default device assignment\n")
 
-    # Use explicit spawn context to avoid CUDA issues with fork
-    ctx = mp.get_context("spawn")
-    with ProcessPoolExecutor(max_workers=n_processes, mp_context=ctx) as executor:
-        # Submit all tasks with round-robin device assignment
-        futures = []
-        for i, xml_file in enumerate(xml_files):
-            device = devices[i % len(devices)] if devices else None
-            future = executor.submit(
-                _run_cross_correlation_single,
-                xml_file,
-                device,
-                lowpass_cutoff,
-                pretilt_search_range,
-            )
-            futures.append(future)
-
-        for future in tqdm(
-            futures,
-            desc="Cross-correlation alignment",
-            unit="tilt series",
-            file=sys.stdout,
-            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
-        ):
-            # This will raise any exception that occurred in the worker
-            future.result()
+    run_device_pool(
+        jobs=xml_files,
+        runner=_cross_correlation_runner,
+        runner_args=(lowpass_cutoff, pretilt_search_range),
+        devices=devices,
+        desc="Cross-correlation alignment",
+    )
 
     print("\nCross-correlation alignment complete!\n")

--- a/src/miss_alignment/preprocessing.py
+++ b/src/miss_alignment/preprocessing.py
@@ -144,6 +144,7 @@ def run_cross_correlation_alignment_parallel(
             desc="Cross-correlation alignment",
             unit="tilt series",
             file=sys.stdout,
+            disable=None,  # auto-disable when stdout is not a TTY (e.g. log file)
         ):
             # This will raise any exception that occurred in the worker
             future.result()

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -181,6 +181,7 @@ def _training_worker(
         log_every_n_steps=50,
         enable_checkpointing=True,
         enable_progress_bar=False,  # disable default progress bar
+        enable_model_summary=False,  # skip the per-iteration params table
         deterministic=False,  # setting to True breaks on max_pool_3d
         limit_val_batches=0,  # turn on validation steps
         num_sanity_val_steps=0,

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -33,6 +33,18 @@ def parse_device_list(value: str) -> list[int]:
     return [int(x.strip()) for x in value.split(",")]
 
 
+def _available_cpus() -> int:
+    """Number of CPUs actually available to this process.
+
+    Uses ``os.sched_getaffinity`` so cgroup/cpuset limits (e.g. SLURM's
+    ``--cpus-per-task``) are respected -- ``os.cpu_count()`` reports the whole
+    node instead. Falls back to ``os.cpu_count()`` where affinity is unavailable.
+    """
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 1
+
+
 def _find_free_port() -> int:
     """Find a free TCP port on localhost for the DDP rendezvous.
 
@@ -336,6 +348,17 @@ def train_miss_align(
         raise ValueError("MissAlignment needs at least 1 training device")
     if len(devices_reconstruction) < 1:
         raise ValueError("MissAlignment needs at least 1 reconstruction worker")
+
+    # torch.compile's Inductor spawns a compile pool of size min(32, n_cpus)
+    # *per process*. With one training rank per GPU on a single node, that is one
+    # pool per rank all competing for the same CPUs (e.g. 4 ranks x 32 = ~128
+    # idle compile workers). Divide the CPU budget across the ranks so the total
+    # stays sane. Set in the main process before spawning so workers inherit it;
+    # setdefault keeps it overridable via the environment.
+    os.environ.setdefault(
+        "TORCHINDUCTOR_COMPILE_THREADS",
+        str(max(1, _available_cpus() // len(devices_training))),
+    )
 
     # For alignment stage, use all visible GPUs
     n_visible_gpus = torch.cuda.device_count()

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -382,15 +382,12 @@ def train_miss_align(
         start_iter, training_directory, model_training_config["model_checkpoint"]
     )
 
-    # make copies of the xml files and model we're starting from
+    # make copies of the xml files we're starting from
     iteration_directory = training_directory / ("iter" + str(start_iter))
     iteration_directory.mkdir(parents=True, exist_ok=True)
     for xml_file in training_directory.glob("*.xml"):
         destination = iteration_directory / xml_file.name
         copyfile(xml_file, destination)
-
-    if training_model_path is not None:
-        copyfile(training_model_path, iteration_directory / "model.ckpt")
 
     for x in range(start_iter, end_iter):
         # ============================================================

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -11,6 +11,7 @@ import torch.multiprocessing as torch_mp
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.loggers import TensorBoardLogger
 from lightning.pytorch.plugins.environments import LightningEnvironment
 from lightning.pytorch.strategies import DDPStrategy
 
@@ -177,6 +178,9 @@ def _training_worker(
         devices=devices_training,
         strategy=strategy,
         default_root_dir=training_directory / "models",
+        # Configure the logger explicitly (matches Lightning's default location)
+        # so it does not emit the "install litlogger" tip every macro-iteration.
+        logger=TensorBoardLogger(save_dir=training_directory / "models"),
         max_epochs=max_epochs,
         log_every_n_steps=50,
         enable_checkpointing=True,

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -1,3 +1,5 @@
+import os
+import socket
 from pathlib import Path
 from shutil import copyfile
 from typing import Optional
@@ -5,7 +7,7 @@ import yaml
 
 import typer
 import torch
-from datetime import timedelta
+import torch.multiprocessing as torch_mp
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint
@@ -18,12 +20,164 @@ from .models import MissAlignment, MAEarlyStopping, MAProgressBar
 from .alignment import run_alignment_parallel
 from .prepare_stacks import prepare_stacks_parallel
 from .preprocessing import run_cross_correlation_alignment_parallel
-from .utils import distributed_barrier, is_rank_zero, rank_zero_print
 
 
 def parse_device_list(value: str) -> list[int]:
     """Parse comma-separated device list like '0,1,2' into [0, 1, 2]."""
     return [int(x.strip()) for x in value.split(",")]
+
+
+def _find_free_port() -> int:
+    """Find a free TCP port on localhost for the DDP rendezvous.
+
+    A fresh port is chosen for every training phase so that re-creating the
+    process group each iteration cannot collide with a socket still lingering
+    in TIME_WAIT from the previous iteration.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _training_worker(
+    rank: int,
+    world_size: int,
+    master_port: int,
+    iteration: int,
+    training_directory: Path,
+    devices_training: list[int],
+    devices_reconstruction: list[int],
+    general_config: dict,
+    model_training_config: dict,
+    data_module_config: dict,
+    shift_generation_config: dict,
+    iteration_settings: dict,
+    dataloaders_per_trainer: int,
+    pool_size: int,
+) -> None:
+    """Run a single model-training phase to completion.
+
+    This is the unit of work that is parallelised across the training GPUs. For
+    multi-GPU training it is launched once per GPU via ``mp.spawn`` and acts as
+    its own process launcher: by exporting ``LOCAL_RANK`` (and the other
+    rendezvous variables) Lightning's ``LightningEnvironment`` detects an
+    external launcher and connects to the existing process group instead of
+    spawning a fresh copy of the whole program. For single-GPU training it is
+    called directly in the main process with ``world_size == 1`` and no DDP.
+
+    Rank 0 publishes the best checkpoint to ``training_directory / model.ckpt``
+    before returning; the main process picks it up from there for alignment.
+    """
+    multi_gpu = world_size > 1
+
+    if multi_gpu:
+        # Act as the process launcher (torchrun/SLURM-style). Lightning keys on
+        # LOCAL_RANK being present to skip its own subprocess launcher.
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(master_port)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["NODE_RANK"] = "0"
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+
+    torch.set_num_threads(1)
+    torch.set_float32_matmul_precision("medium")
+    seed_everything(general_config["seed"], workers=True)
+
+    # Define the early stopping callback
+    early_stopping = MAEarlyStopping(
+        patience=5,  # cycles with no improvement
+        min_delta=0.001,  # minimum change to qualify as an improvement
+        wait_for_scheduler=True,
+    )
+
+    # save checkpoints based on training loss performance
+    checkpoint_callback = ModelCheckpoint(
+        monitor="train_loss",
+        mode="min",  # 'min' for loss, 'max' for accuracy
+        save_top_k=3,  # Keep 5 best checkpoints
+        filename=str(iteration) + "_{epoch}--{step}--{train_loss:.3f}",
+        save_on_train_epoch_end=True,
+    )
+
+    # Progress bar showing total progress across all epochs
+    max_epochs = model_training_config["max_epochs_per_iteration"]
+    progress_bar = MAProgressBar(
+        max_epochs=max_epochs,
+        steps_per_epoch=data_module_config["steps_per_epoch"],
+        refresh_rate=10,
+    )
+
+    # Use DDP only for multi-GPU; the workers live only for this fit() call, so
+    # the default DDP timeout is fine (no rank sits idle during alignment).
+    strategy = (
+        DDPStrategy(find_unused_parameters=False)  # feed-forward model
+        if multi_gpu
+        else "auto"
+    )
+    trainer = Trainer(
+        accelerator="gpu",
+        devices=devices_training,
+        strategy=strategy,
+        default_root_dir=training_directory / "models",
+        max_epochs=max_epochs,
+        log_every_n_steps=50,
+        enable_checkpointing=True,
+        enable_progress_bar=False,  # disable default progress bar
+        deterministic=False,  # setting to True breaks on max_pool_3d
+        limit_val_batches=0,  # turn on validation steps
+        num_sanity_val_steps=0,
+        callbacks=[early_stopping, checkpoint_callback, progress_bar],
+        precision="16-mixed",  # Enable automatic mixed precision
+        benchmark=True,  # cuDNN caches fastest conv algo for fixed input shape
+    )
+
+    # Initialize model with parameters from config
+    # Scale learning rate by number of GPUs (linear scaling rule)
+    scaled_learning_rate = model_training_config["learning_rate"] * len(
+        devices_training
+    )
+    model_params = {
+        "learning_rate": scaled_learning_rate,
+        "margin": model_training_config["loss_margin"],
+        "weight_decay": float(model_training_config["weight_decay"]),
+        "warmup_steps": model_training_config["warmup_steps"],
+        "multistep_lr_scheduler": model_training_config["multistep_lr_scheduler"],
+        "model_architecture": model_training_config["model_architecture"],
+    }
+
+    if model_training_config["model_checkpoint"] is not None:
+        model = MissAlignment.load_from_checkpoint(
+            model_training_config["model_checkpoint"], **model_params
+        )
+    else:
+        model = MissAlignment(**model_params)
+
+    # Each GPU uses the full batch size (effective batch size scales with GPUs)
+    with MissAlignmentDataModule(
+        training_directory,
+        create_default_generator(**shift_generation_config),
+        reconstruction_accelerators=devices_reconstruction,
+        n_training_devices=len(devices_training),
+        batch_size=data_module_config["batch_size"],
+        patch_size=data_module_config["patch_size"],
+        apply_ctf=general_config["apply_ctf"],
+        downsample=iteration_settings["downsample"],
+        steps_per_epoch=data_module_config["steps_per_epoch"],
+        pool_size=pool_size,
+        dataloader_workers=dataloaders_per_trainer,
+    ) as dm:
+        # enter datamodule context to start the reconstruction worker pool
+        # passing datamodule lets Lightning apply DistributedSampler
+        trainer.fit(model, datamodule=dm)
+
+    # Rank 0 publishes the best checkpoint at a known path for the main process.
+    if trainer.is_global_zero:
+        best_model_path = Path(trainer.checkpoint_callback.best_model_path)
+        training_model_path = training_directory / "model.ckpt"
+        copyfile(best_model_path, training_model_path)
+        print(f"Best model after iteration {iteration}: {best_model_path}")
+        print(f"Copied best model to {training_model_path}")
 
 
 @cli.command(name="train", no_args_is_help=True)
@@ -69,11 +223,6 @@ def train_miss_align(
         help="Run cross-correlation based alignment before training iterations. "
         "This performs coarse alignment with pretilt estimation.",
     ),
-    ddp_timeout_hours: float = typer.Option(
-        6.0,
-        help="Timeout in hours for DDP communication during multi-GPU training. "
-        "Increase this if alignment takes longer than expected.",
-    ),
 ) -> None:
     """Train MissAlignment on a dataset using configuration from a YAML file."""
 
@@ -94,9 +243,9 @@ def train_miss_align(
     n_visible_gpus = torch.cuda.device_count()
     devices_alignment = list(range(n_visible_gpus))
 
-    rank_zero_print(f"Using devices {devices_training} for training")
-    rank_zero_print(f"Using devices {devices_reconstruction} for reconstruction")
-    rank_zero_print(f"Using devices {devices_alignment} for alignment")
+    print(f"Using devices {devices_training} for training")
+    print(f"Using devices {devices_reconstruction} for reconstruction")
+    print(f"Using devices {devices_alignment} for alignment")
 
     # Load configuration from YAML file
     with open(config_file, "r") as f:
@@ -118,57 +267,55 @@ def train_miss_align(
     seed = general_config["seed"]
     seed_everything(seed, workers=True)
 
-    if is_rank_zero():
-        # Prepare tilt stacks if requested
-        if prepare_stacks is not None:
-            if prepare_stacks <= 0:
-                raise ValueError("--prepare-stacks must be a positive non-zero number")
-            prepare_stacks_parallel(
-                training_directory=training_directory,
-                desired_pixel_size=prepare_stacks,
-                n_processes=4,
-                devices=devices_alignment,
+    # Prepare tilt stacks if requested
+    if prepare_stacks is not None:
+        if prepare_stacks <= 0:
+            raise ValueError("--prepare-stacks must be a positive non-zero number")
+        prepare_stacks_parallel(
+            training_directory=training_directory,
+            desired_pixel_size=prepare_stacks,
+            n_processes=4,
+            devices=devices_alignment,
+        )
+
+    # Run preprocessing if requested
+    if preprocess:
+        if start_at_iteration != 0:
+            raise ValueError(
+                "Running preprocessing at while "
+                "not starting at iteration 0. This "
+                "is likely not desirable behaviour."
             )
+        else:
+            # Back up original data to pre-iter directory
+            preiter_directory = training_directory / "pre-iter"
+            preiter_directory.mkdir(parents=True, exist_ok=True)
+            for xml_file in training_directory.glob("*.xml"):
+                destination = preiter_directory / xml_file.name
+                copyfile(xml_file, destination)
+            print(f"Backed up original metadata to {preiter_directory}")
 
-        # Run preprocessing if requested
-        if preprocess:
-            if start_at_iteration != 0:
-                raise ValueError(
-                    "Running preprocessing at while "
-                    "not starting at iteration 0. This "
-                    "is likely not desirable behaviour."
-                )
-            else:
-                # Back up original data to pre-iter directory
-                preiter_directory = training_directory / "pre-iter"
-                preiter_directory.mkdir(parents=True, exist_ok=True)
-                for xml_file in training_directory.glob("*.xml"):
-                    destination = preiter_directory / xml_file.name
-                    copyfile(xml_file, destination)
-                rank_zero_print(f"Backed up original metadata to {preiter_directory}")
-
-                # Run cross-correlation alignment on the training directory
-                run_cross_correlation_alignment_parallel(
-                    training_directory=training_directory,
-                    devices=devices_alignment,
-                    n_processes=4,
-                )
+            # Run cross-correlation alignment on the training directory
+            run_cross_correlation_alignment_parallel(
+                training_directory=training_directory,
+                devices=devices_alignment,
+                n_processes=4,
+            )
 
     start_iter = start_at_iteration
     end_iter = len(general_config["iteration_settings"])
 
-    if is_rank_zero():
-        # make copies of the xml files and (model) we're starting from
-        iteration_directory = training_directory / ("iter" + str(start_iter))
-        iteration_directory.mkdir(parents=True, exist_ok=True)
-        for xml_file in training_directory.glob("*.xml"):
-            destination = iteration_directory / xml_file.name
-            copyfile(xml_file, destination)
+    # make copies of the xml files and (model) we're starting from
+    iteration_directory = training_directory / ("iter" + str(start_iter))
+    iteration_directory.mkdir(parents=True, exist_ok=True)
+    for xml_file in training_directory.glob("*.xml"):
+        destination = iteration_directory / xml_file.name
+        copyfile(xml_file, destination)
 
-        if model_training_config["model_checkpoint"] is not None:
-            source = model_training_config["model_checkpoint"]
-            destination = iteration_directory / Path(source).name
-            copyfile(source, destination)
+    if model_training_config["model_checkpoint"] is not None:
+        source = model_training_config["model_checkpoint"]
+        destination = iteration_directory / Path(source).name
+        copyfile(source, destination)
 
     for x in range(start_iter, end_iter):
         # ============================================================
@@ -176,167 +323,80 @@ def train_miss_align(
         # ============================================================
         iteration_settings = general_config["iteration_settings"][x]
         alignment_mode = iteration_settings["alignment"]
-        rank_zero_print(f"\n{'=' * 60}")
-        rank_zero_print(f"Iteration {x + 1}/{end_iter} - Alignment: {alignment_mode}")
-        rank_zero_print(f"{'=' * 60}\n")
+        print(f"\n{'=' * 60}")
+        print(f"Iteration {x + 1}/{end_iter} - Alignment: {alignment_mode}")
+        print(f"{'=' * 60}\n")
 
-        # Define the early stopping callback
-        early_stopping = MAEarlyStopping(
-            patience=5,  # cycles with no improvement
-            min_delta=0.001,  # minimum change to qualify as an improvement
-            wait_for_scheduler=True,
+        # Run the training phase. Multi-GPU spawns one DDP worker per training
+        # device and joins; single-GPU runs in-process. Either way the main
+        # process is single-process again once this returns, with the best
+        # checkpoint published at training_directory / model.ckpt.
+        world_size = len(devices_training)
+        worker_args = (
+            world_size,
+            _find_free_port(),
+            x,
+            training_directory,
+            devices_training,
+            devices_reconstruction,
+            general_config,
+            model_training_config,
+            data_module_config,
+            shift_generation_config,
+            iteration_settings,
+            dataloaders_per_trainer,
+            pool_size,
         )
-
-        # save checkpoints based on training loss performance
-        checkpoint_callback = ModelCheckpoint(
-            monitor="train_loss",
-            mode="min",  # 'min' for loss, 'max' for accuracy
-            save_top_k=3,  # Keep 5 best checkpoints
-            filename=str(x) + "_{epoch}--{step}--{train_loss:.3f}",
-            save_on_train_epoch_end=True,
-        )
-
-        # Progress bar showing total progress across all epochs
-        max_epochs = model_training_config["max_epochs_per_iteration"]
-        steps_per_epoch = data_module_config["steps_per_epoch"]
-        progress_bar = MAProgressBar(
-            max_epochs=max_epochs,
-            steps_per_epoch=steps_per_epoch,
-            refresh_rate=10,
-        )
-
-        # Set up trainer with parameters from config
-        # Use DDP strategy for multi-GPU training with extended timeout
-        # Default is 30 min, but alignment can take much longer while other ranks wait
-        strategy = (
-            DDPStrategy(
-                timeout=timedelta(hours=ddp_timeout_hours),
-                find_unused_parameters=False,  # feed-forward model, no unused params
-            )
-            if len(devices_training) > 1
-            else "auto"
-        )
-        trainer = Trainer(
-            accelerator="gpu",
-            devices=devices_training,
-            strategy=strategy,
-            default_root_dir=training_directory / "models",
-            max_epochs=max_epochs,
-            log_every_n_steps=50,
-            enable_checkpointing=True,
-            enable_progress_bar=False,  # disable default progress bar
-            deterministic=False,  # setting to True breaks on max_pool_3d
-            limit_val_batches=0,  # turn on validation steps
-            num_sanity_val_steps=0,
-            callbacks=[early_stopping, checkpoint_callback, progress_bar],
-            precision="16-mixed",  # Enable automatic mixed precision
-            benchmark=True,  # cuDNN caches fastest conv algo for fixed input shape
-        )
-
-        # Initialize model with parameters from config
-        # Scale learning rate by number of GPUs (linear scaling rule)
-        scaled_learning_rate = model_training_config["learning_rate"] * len(
-            devices_training
-        )
-        model_params = {
-            "learning_rate": scaled_learning_rate,
-            "margin": model_training_config["loss_margin"],
-            "weight_decay": float(model_training_config["weight_decay"]),
-            "warmup_steps": model_training_config["warmup_steps"],
-            "multistep_lr_scheduler": model_training_config["multistep_lr_scheduler"],
-            "model_architecture": model_training_config["model_architecture"],
-        }
-
-        if model_training_config["model_checkpoint"] is not None:
-            model = MissAlignment.load_from_checkpoint(
-                model_training_config["model_checkpoint"], **model_params
+        if world_size > 1:
+            torch_mp.spawn(
+                _training_worker, args=worker_args, nprocs=world_size, join=True
             )
         else:
-            model = MissAlignment(**model_params)
+            _training_worker(0, *worker_args)
 
-        # Initialize data module with parameters from config
-        # Each GPU uses the full batch size (effective batch size scales with GPUs)
-        batch_size_per_device = data_module_config["batch_size"]
+        # This known path was written by rank 0 and is used for alignment and
+        # as the starting checkpoint for the next iteration.
+        training_model_path = training_directory / "model.ckpt"
 
-        with MissAlignmentDataModule(
-            training_directory,
-            create_default_generator(**shift_generation_config),
-            reconstruction_accelerators=devices_reconstruction,
-            n_training_devices=len(devices_training),
-            batch_size=batch_size_per_device,
-            patch_size=data_module_config["patch_size"],
+        # ============================================================
+        # =============== tilt-series alignment step =================
+        # ============================================================
+
+        # get list of all files to process for alignment
+        tilt_series_list = list(training_directory.glob("*.xml"))
+
+        # run alignment in parallel over all available devices
+        run_alignment_parallel(
+            model_checkpoint=str(training_model_path),
+            tilt_series_list=tilt_series_list,
+            output_directory=training_directory,
+            setting=iteration_settings["alignment"],
+            patch_size=alignment_config["patch_size"],
+            patch_overlap=alignment_config["patch_overlap"],
+            batch_size=alignment_config["batch_size"],
             apply_ctf=general_config["apply_ctf"],
             downsample=iteration_settings["downsample"],
-            steps_per_epoch=data_module_config["steps_per_epoch"],
-            pool_size=pool_size,
-            dataloader_workers=dataloaders_per_trainer,
-        ) as dm:
-            # enter datamodule context to start the reconstruction worker pool
-            # passing datamodule lets Lightning apply DistributedSampler
-            trainer.fit(model, datamodule=dm)
-
-            # Synchronize all ranks after training, while DDP is still active
-            # This must be BEFORE the context manager exits, as Lightning's DDP
-            # process group may become invalid during/after teardown
-            distributed_barrier()
-
-        # Only rank 0 performs alignment and file operations
-        # Other ranks wait at the barrier at the end of the iteration
-        if is_rank_zero():
-            best_model_path = Path(trainer.checkpoint_callback.best_model_path)
-            rank_zero_print(f"Best model after iteration {x}:", best_model_path)
-
-            # copy best model to training directory as model.ckpt
-            # This known path is used by all ranks for the next iteration
-            training_model_path = training_directory / "model.ckpt"
-            copyfile(best_model_path, training_model_path)
-            rank_zero_print(f"Copied best model to {training_model_path}")
-
-            # ============================================================
-            # =============== tilt-series alignment step =================
-            # ============================================================
-
-            # get list of all files to process for alignment
-            tilt_series_list = list(training_directory.glob("*.xml"))
-
-            # run alignment in parallel over all available devices
-            run_alignment_parallel(
-                model_checkpoint=str(training_model_path),
-                tilt_series_list=tilt_series_list,
-                output_directory=training_directory,
-                setting=iteration_settings["alignment"],
-                patch_size=alignment_config["patch_size"],
-                patch_overlap=alignment_config["patch_overlap"],
-                batch_size=alignment_config["batch_size"],
-                apply_ctf=general_config["apply_ctf"],
-                downsample=iteration_settings["downsample"],
-                devices_list=devices_alignment,
-            )
-
-            # make copies of the xml files and model after alignment
-            iteration_directory = training_directory / ("iter" + str(x + 1))
-            iteration_directory.mkdir(parents=True, exist_ok=True)
-
-            for xml_file in training_directory.glob("*.xml"):
-                destination_xml = iteration_directory / xml_file.name
-                copyfile(xml_file, destination_xml)
-
-                # copy the file with the alignment loss
-                loss_json = xml_file.stem + "_alignment_loss.json"
-                destination_json = iteration_directory / loss_json
-                copyfile(training_directory / loss_json, destination_json)
-
-            iteration_model_path = iteration_directory / "model.ckpt"
-            copyfile(best_model_path, iteration_model_path)
-            rank_zero_print(f"Copied best model to {iteration_model_path}")
-
-        # All ranks use the known model.ckpt path for the next iteration
-        # (rank 0 wrote it above, barrier below ensures it exists)
-        model_training_config["model_checkpoint"] = str(
-            training_directory / "model.ckpt"
+            devices_list=devices_alignment,
         )
 
-        # Synchronize all ranks before starting the next iteration
-        distributed_barrier()
+        # make copies of the xml files and model after alignment
+        iteration_directory = training_directory / ("iter" + str(x + 1))
+        iteration_directory.mkdir(parents=True, exist_ok=True)
+
+        for xml_file in training_directory.glob("*.xml"):
+            destination_xml = iteration_directory / xml_file.name
+            copyfile(xml_file, destination_xml)
+
+            # copy the file with the alignment loss
+            loss_json = xml_file.stem + "_alignment_loss.json"
+            destination_json = iteration_directory / loss_json
+            copyfile(training_directory / loss_json, destination_json)
+
+        iteration_model_path = iteration_directory / "model.ckpt"
+        copyfile(training_model_path, iteration_model_path)
+        print(f"Copied best model to {iteration_model_path}")
+
+        # The next iteration starts from the model we just trained.
+        model_training_config["model_checkpoint"] = str(training_model_path)
 
     return None

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -11,6 +11,7 @@ import torch.multiprocessing as torch_mp
 
 from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.plugins.environments import LightningEnvironment
 from lightning.pytorch.strategies import DDPStrategy
 
 from ._cli import OPTION_PROMPT_KWARGS, cli
@@ -110,8 +111,16 @@ def _training_worker(
 
     # Use DDP only for multi-GPU; the workers live only for this fit() call, so
     # the default DDP timeout is fine (no rank sits idle during alignment).
+    # Pin the cluster environment so that we (the mp.spawn launcher) stay in
+    # control of the ranks. Without this, Lightning auto-detects SLURMEnvironment
+    # inside any SLURM allocation and reads SLURM_PROCID/SLURM_NTASKS instead of
+    # the RANK/WORLD_SIZE/LOCAL_RANK we export, which would collapse the spawned
+    # workers into world_size=1. LightningEnvironment keys off LOCAL_RANK.
     strategy = (
-        DDPStrategy(find_unused_parameters=False)  # feed-forward model
+        DDPStrategy(
+            cluster_environment=LightningEnvironment(),
+            find_unused_parameters=False,  # feed-forward model
+        )
         if multi_gpu
         else "auto"
     )

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -467,7 +467,6 @@ def train_miss_align(
 
         iteration_model_path = iteration_directory / "model.ckpt"
         copyfile(training_model_path, iteration_model_path)
-        print(f"Copied best model to {iteration_model_path}")
 
         # training_model_path now points at the model just trained
         # (set after the worker above); the next iteration starts from it.

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -296,9 +296,12 @@ def train_miss_align(
     n_visible_gpus = torch.cuda.device_count()
     devices_alignment = list(range(n_visible_gpus))
 
-    print(f"Using devices {devices_training} for training")
-    print(f"Using devices {devices_reconstruction} for reconstruction")
-    print(f"Using devices {devices_alignment} for alignment")
+    # Each macro-iteration runs two phases; report which devices each one uses.
+    print("Macro-iteration phase 1 (model training):")
+    print(f"  training devices:       {devices_training}")
+    print(f"  reconstruction devices: {devices_reconstruction}")
+    print("Macro-iteration phase 2 (tilt-series alignment):")
+    print(f"  alignment devices:      {devices_alignment}")
 
     # Load configuration from YAML file
     with open(config_file, "r") as f:

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -40,6 +40,22 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
+def _set_ddp_env(rank: int, world_size: int, master_port: int) -> None:
+    """Export the rendezvous variables so we act as the DDP process launcher.
+
+    Lightning's ``LightningEnvironment`` keys on ``LOCAL_RANK`` being present to
+    detect an external launcher (torchrun/SLURM-style) and connect to this
+    existing process group instead of spawning a fresh copy of the program.
+    Single-node only, so the master address is always localhost.
+    """
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["NODE_RANK"] = "0"
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+
+
 def _training_worker(
     rank: int,
     world_size: int,
@@ -72,14 +88,7 @@ def _training_worker(
     multi_gpu = world_size > 1
 
     if multi_gpu:
-        # Act as the process launcher (torchrun/SLURM-style). Lightning keys on
-        # LOCAL_RANK being present to skip its own subprocess launcher.
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = str(master_port)
-        os.environ["WORLD_SIZE"] = str(world_size)
-        os.environ["NODE_RANK"] = "0"
-        os.environ["RANK"] = str(rank)
-        os.environ["LOCAL_RANK"] = str(rank)
+        _set_ddp_env(rank, world_size, master_port)
 
     torch.set_num_threads(1)
     torch.set_float32_matmul_precision("medium")

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -129,7 +129,9 @@ def _training_worker(
 
     torch.set_num_threads(1)
     torch.set_float32_matmul_precision("medium")
-    seed_everything(general_config["seed"], workers=True)
+    # verbose=False: the main process already logs the seed once at startup;
+    # without this every rank reprints it on every macro-iteration.
+    seed_everything(general_config["seed"], workers=True, verbose=False)
 
     # Define the early stopping callback
     early_stopping = MAEarlyStopping(

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import socket
 from pathlib import Path
@@ -23,6 +24,8 @@ from .models import MissAlignment, MAEarlyStopping, MAProgressBar
 from .alignment import run_alignment_parallel
 from .prepare_stacks import prepare_stacks_parallel
 from .preprocessing import run_cross_correlation_alignment_parallel
+
+logger = logging.getLogger(__name__)
 
 
 def parse_device_list(value: str) -> list[int]:
@@ -87,9 +90,9 @@ def _resolve_start_checkpoint(
             f"loading model from {fallback_checkpoint}"
         )
         return fallback_checkpoint
-    print(
-        f"Warning: resuming at iteration {start_iter} but no model checkpoint "
-        "found; training will start from random weights."
+    logger.warning(
+        f"Resuming at iteration {start_iter} but no model checkpoint found; "
+        "training will start from random weights."
     )
     return None
 

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -97,6 +97,33 @@ def _resolve_start_checkpoint(
     return None
 
 
+def _sync_start_iteration_xmls(start_iter: int, training_directory: Path) -> None:
+    """Align the working XMLs with the ``iter{start_iter}/`` snapshot.
+
+    iter 0 (fresh run): back up the original alignments from the training
+    directory into ``iter0/`` as the baseline.
+
+    Resuming (``start_iter > 0``): restore the working alignments *from*
+    ``iter{start_iter}/`` (written at the end of the previous iteration) back
+    into the training directory, so the run continues from the correct state
+    even if a previous attempt crashed partway through this iteration.
+    """
+    iteration_directory = training_directory / f"iter{start_iter}"
+
+    if start_iter == 0:
+        iteration_directory.mkdir(parents=True, exist_ok=True)
+        for xml_file in training_directory.glob("*.xml"):
+            copyfile(xml_file, iteration_directory / xml_file.name)
+    else:
+        if not iteration_directory.is_dir():
+            raise FileNotFoundError(
+                f"Cannot resume at iteration {start_iter}: "
+                f"{iteration_directory} does not exist."
+            )
+        for xml_file in iteration_directory.glob("*.xml"):
+            copyfile(xml_file, training_directory / xml_file.name)
+
+
 def _training_worker(
     rank: int,
     world_size: int,
@@ -382,12 +409,9 @@ def train_miss_align(
         start_iter, training_directory, model_training_config["model_checkpoint"]
     )
 
-    # make copies of the xml files we're starting from
-    iteration_directory = training_directory / ("iter" + str(start_iter))
-    iteration_directory.mkdir(parents=True, exist_ok=True)
-    for xml_file in training_directory.glob("*.xml"):
-        destination = iteration_directory / xml_file.name
-        copyfile(xml_file, destination)
+    # iter 0 snapshots the input alignments as a baseline; resuming restores the
+    # working alignments from that iteration's snapshot.
+    _sync_start_iteration_xmls(start_iter, training_directory)
 
     for x in range(start_iter, end_iter):
         # ============================================================

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -157,18 +157,45 @@ def train_miss_align(
     start_iter = start_at_iteration
     end_iter = len(general_config["iteration_settings"])
 
+    # Determine the model checkpoint to use for the first training iteration.
+    # When starting fresh (iter 0), use the checkpoint from the config if provided.
+    # When resuming, always load from the backup written at the end of the previous
+    # iteration; the config's model_checkpoint is irrelevant in that case.
+    if start_iter == 0:
+        config_checkpoint = model_training_config["model_checkpoint"]
+        training_model_path = Path(config_checkpoint) if config_checkpoint else None
+    else:
+        iter_checkpoint = training_directory / f"iter{start_iter}" / "model.ckpt"
+        fallback_checkpoint = training_directory / "model.ckpt"
+        if iter_checkpoint.exists():
+            training_model_path = iter_checkpoint
+            rank_zero_print(
+                f"Resuming at iteration {start_iter}: "
+                f"loading model from {training_model_path}"
+            )
+        elif fallback_checkpoint.exists():
+            training_model_path = fallback_checkpoint
+            rank_zero_print(
+                f"Resuming at iteration {start_iter}: "
+                f"loading model from {training_model_path}"
+            )
+        else:
+            training_model_path = None
+            rank_zero_print(
+                f"Warning: resuming at iteration {start_iter} but no model "
+                "checkpoint found; training will start from random weights."
+            )
+
     if is_rank_zero():
-        # make copies of the xml files and (model) we're starting from
+        # make copies of the xml files and model we're starting from
         iteration_directory = training_directory / ("iter" + str(start_iter))
         iteration_directory.mkdir(parents=True, exist_ok=True)
         for xml_file in training_directory.glob("*.xml"):
             destination = iteration_directory / xml_file.name
             copyfile(xml_file, destination)
 
-        if model_training_config["model_checkpoint"] is not None:
-            source = model_training_config["model_checkpoint"]
-            destination = iteration_directory / Path(source).name
-            copyfile(source, destination)
+        if training_model_path is not None:
+            copyfile(training_model_path, iteration_directory / "model.ckpt")
 
     for x in range(start_iter, end_iter):
         # ============================================================
@@ -247,9 +274,9 @@ def train_miss_align(
             "model_architecture": model_training_config["model_architecture"],
         }
 
-        if model_training_config["model_checkpoint"] is not None:
+        if training_model_path is not None:
             model = MissAlignment.load_from_checkpoint(
-                model_training_config["model_checkpoint"], **model_params
+                str(training_model_path), **model_params
             )
         else:
             model = MissAlignment(**model_params)
@@ -287,10 +314,9 @@ def train_miss_align(
             rank_zero_print(f"Best model after iteration {x}:", best_model_path)
 
             # copy best model to training directory as model.ckpt
-            # This known path is used by all ranks for the next iteration
-            training_model_path = training_directory / "model.ckpt"
-            copyfile(best_model_path, training_model_path)
-            rank_zero_print(f"Copied best model to {training_model_path}")
+            new_training_model_path = training_directory / "model.ckpt"
+            copyfile(best_model_path, new_training_model_path)
+            rank_zero_print(f"Copied best model to {new_training_model_path}")
 
             # ============================================================
             # =============== tilt-series alignment step =================
@@ -301,7 +327,7 @@ def train_miss_align(
 
             # run alignment in parallel over all available devices
             run_alignment_parallel(
-                model_checkpoint=str(training_model_path),
+                model_checkpoint=str(new_training_model_path),
                 tilt_series_list=tilt_series_list,
                 output_directory=training_directory,
                 setting=iteration_settings["alignment"],
@@ -330,11 +356,10 @@ def train_miss_align(
             copyfile(best_model_path, iteration_model_path)
             rank_zero_print(f"Copied best model to {iteration_model_path}")
 
-        # All ranks use the known model.ckpt path for the next iteration
-        # (rank 0 wrote it above, barrier below ensures it exists)
-        model_training_config["model_checkpoint"] = str(
-            training_directory / "model.ckpt"
-        )
+        # All ranks update training_model_path for the next iteration.
+        # Rank 0 wrote training_directory/model.ckpt above; the barrier below
+        # ensures it exists before any rank reads it.
+        training_model_path = training_directory / "model.ckpt"
 
         # Synchronize all ranks before starting the next iteration
         distributed_barrier()

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -348,7 +348,6 @@ def train_miss_align(
         prepare_stacks_parallel(
             training_directory=training_directory,
             desired_pixel_size=prepare_stacks,
-            n_processes=4,
             devices=devices_alignment,
         )
 
@@ -373,7 +372,6 @@ def train_miss_align(
             run_cross_correlation_alignment_parallel(
                 training_directory=training_directory,
                 devices=devices_alignment,
-                n_processes=4,
             )
 
     start_iter = start_at_iteration

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -56,6 +56,42 @@ def _set_ddp_env(rank: int, world_size: int, master_port: int) -> None:
     os.environ["LOCAL_RANK"] = str(rank)
 
 
+def _resolve_start_checkpoint(
+    start_iter: int,
+    training_directory: Path,
+    config_checkpoint: Optional[str],
+) -> Optional[Path]:
+    """Pick the checkpoint to start the first training iteration from.
+
+    iter 0 uses the config's ``model_checkpoint`` (or None for random weights).
+    When resuming (``start_iter > 0``), load the model saved at the end of the
+    previous iteration (``iter{start_iter}/model.ckpt``), falling back to
+    ``training_directory/model.ckpt``; the config's checkpoint is irrelevant in
+    that case. Returns None (train from scratch) if no checkpoint is found.
+    """
+    if start_iter == 0:
+        return Path(config_checkpoint) if config_checkpoint else None
+
+    iter_checkpoint = training_directory / f"iter{start_iter}" / "model.ckpt"
+    fallback_checkpoint = training_directory / "model.ckpt"
+    if iter_checkpoint.exists():
+        print(
+            f"Resuming at iteration {start_iter}: loading model from {iter_checkpoint}"
+        )
+        return iter_checkpoint
+    if fallback_checkpoint.exists():
+        print(
+            f"Resuming at iteration {start_iter}: "
+            f"loading model from {fallback_checkpoint}"
+        )
+        return fallback_checkpoint
+    print(
+        f"Warning: resuming at iteration {start_iter} but no model checkpoint "
+        "found; training will start from random weights."
+    )
+    return None
+
+
 def _training_worker(
     rank: int,
     world_size: int,
@@ -322,34 +358,10 @@ def train_miss_align(
     start_iter = start_at_iteration
     end_iter = len(general_config["iteration_settings"])
 
-    # Determine the model checkpoint to use for the first training iteration.
-    # When starting fresh (iter 0), use the checkpoint from the config if provided.
-    # When resuming, always load from the backup written at the end of the previous
-    # iteration; the config's model_checkpoint is irrelevant in that case.
-    if start_iter == 0:
-        config_checkpoint = model_training_config["model_checkpoint"]
-        training_model_path = Path(config_checkpoint) if config_checkpoint else None
-    else:
-        iter_checkpoint = training_directory / f"iter{start_iter}" / "model.ckpt"
-        fallback_checkpoint = training_directory / "model.ckpt"
-        if iter_checkpoint.exists():
-            training_model_path = iter_checkpoint
-            print(
-                f"Resuming at iteration {start_iter}: "
-                f"loading model from {training_model_path}"
-            )
-        elif fallback_checkpoint.exists():
-            training_model_path = fallback_checkpoint
-            print(
-                f"Resuming at iteration {start_iter}: "
-                f"loading model from {training_model_path}"
-            )
-        else:
-            training_model_path = None
-            print(
-                f"Warning: resuming at iteration {start_iter} but no model "
-                "checkpoint found; training will start from random weights."
-            )
+    # Determine the model checkpoint to start the first training iteration from.
+    training_model_path = _resolve_start_checkpoint(
+        start_iter, training_directory, model_training_config["model_checkpoint"]
+    )
 
     # make copies of the xml files and model we're starting from
     iteration_directory = training_directory / ("iter" + str(start_iter))

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import socket
 from pathlib import Path
@@ -133,6 +134,12 @@ def _training_worker(
     # verbose=False: the main process already logs the seed once at startup;
     # without this every rank reprints it on every macro-iteration.
     seed_everything(general_config["seed"], workers=True, verbose=False)
+
+    # Quiet Lightning's INFO startup banners (GPU available, Initializing
+    # distributed, LOCAL_RANK..., etc.), which repeat per rank every
+    # macro-iteration. Warnings and errors still surface. This is Lightning's
+    # documented logger knob rather than reaching into internal logger names.
+    logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
 
     # Define the early stopping callback
     early_stopping = MAEarlyStopping(

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import socket
 from pathlib import Path
@@ -17,6 +16,7 @@ from lightning.pytorch.plugins.environments import LightningEnvironment
 from lightning.pytorch.strategies import DDPStrategy
 
 from ._cli import OPTION_PROMPT_KWARGS, cli
+from .utils import configure_logging
 from .data import MissAlignmentDataModule
 from .data.shift_generation import create_default_generator
 from .models import MissAlignment, MAEarlyStopping, MAProgressBar
@@ -129,17 +129,15 @@ def _training_worker(
     if multi_gpu:
         _set_ddp_env(rank, world_size, master_port)
 
+    # Spawned worker: re-apply logging config (env vars survive the spawn,
+    # runtime logging config does not) and quiet Lightning's INFO banners.
+    configure_logging()
+
     torch.set_num_threads(1)
     torch.set_float32_matmul_precision("medium")
     # verbose=False: the main process already logs the seed once at startup;
     # without this every rank reprints it on every macro-iteration.
     seed_everything(general_config["seed"], workers=True, verbose=False)
-
-    # Quiet Lightning's INFO startup banners (GPU available, Initializing
-    # distributed, LOCAL_RANK..., etc.), which repeat per rank every
-    # macro-iteration. Warnings and errors still surface. This is Lightning's
-    # documented logger knob rather than reaching into internal logger names.
-    logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
 
     # Define the early stopping callback
     early_stopping = MAEarlyStopping(
@@ -292,6 +290,9 @@ def train_miss_align(
     ),
 ) -> None:
     """Train MissAlignment on a dataset using configuration from a YAML file."""
+
+    # honor MISS_ALIGNMENT_LOG_LEVEL and quiet Lightning's banners
+    configure_logging()
 
     # check hardware settings, we assume gpu's are available and limit
     # cpu multithreading

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -33,9 +33,12 @@ def configure_logging() -> None:
         pkg_logger.addHandler(handler)
         pkg_logger.propagate = False  # avoid double emission via the root logger
 
-    # Mute the whole lightning namespace (both lightning.pytorch and
-    # lightning.fabric, which logs "Initializing distributed: ...").
-    logging.getLogger("lightning").setLevel(logging.WARNING)
+    # Mute Lightning's INFO startup banners. Both lightning.pytorch and
+    # lightning.fabric give their own logger an explicit INFO level (with a
+    # handler and propagate=False) at import, so the level must be set on each
+    # directly -- setting the parent "lightning" logger has no effect.
+    for name in ("lightning.pytorch", "lightning.fabric"):
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 def is_rank_zero() -> bool:

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -33,7 +33,9 @@ def configure_logging() -> None:
         pkg_logger.addHandler(handler)
         pkg_logger.propagate = False  # avoid double emission via the root logger
 
-    logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
+    # Mute the whole lightning namespace (both lightning.pytorch and
+    # lightning.fabric, which logs "Initializing distributed: ...").
+    logging.getLogger("lightning").setLevel(logging.WARNING)
 
 
 def is_rank_zero() -> bool:

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -10,12 +10,12 @@ def is_rank_zero() -> bool:
 
     Check order:
     1. torch.distributed (always correct when initialized)
-    2. LOCAL_RANK (set by Lightning's LightningEnvironment for each spawned process)
+    2. LOCAL_RANK env var, set by the training worker before the process group
+       exists (e.g. at datamodule __enter__) and read by Lightning's
+       LightningEnvironment to detect the external launcher
 
-    SLURM_PROCID is intentionally not checked: without srun it is 0 for all
-    processes spawned from a single SLURM task, making it actively misleading.
-    With srun, torch.distributed is initialized before this function is called
-    in any meaningful context, so SLURM_PROCID is never needed.
+    Single-GPU training sets neither, so the final ``return True`` covers the
+    in-process (rank 0) case.
     """
     if torch.distributed.is_initialized():
         return torch.distributed.get_rank() == 0
@@ -25,22 +25,3 @@ def is_rank_zero() -> bool:
         return int(local_rank) == 0
 
     return True
-
-
-def rank_zero_print(*args, **kwargs) -> None:
-    """Print only on rank 0 in DDP training.
-
-    All arguments are passed directly to the built-in print function.
-    """
-    if is_rank_zero():
-        print(*args, **kwargs)
-
-
-def distributed_barrier() -> None:
-    """Synchronize all processes in distributed training.
-
-    This is a no-op if distributed training is not initialized (single GPU).
-    Use this to ensure all ranks wait before/after non-distributed operations.
-    """
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()

--- a/src/miss_alignment/utils.py
+++ b/src/miss_alignment/utils.py
@@ -1,8 +1,39 @@
 """Utility functions for miss-alignment."""
 
+import logging
 import os
 
 import torch
+
+# Env var controlling miss-alignment's own log verbosity (DEBUG/INFO/WARNING/...).
+LOG_LEVEL_ENV_VAR = "MISS_ALIGNMENT_LOG_LEVEL"
+
+
+def configure_logging() -> None:
+    """Configure miss-alignment logging from ``MISS_ALIGNMENT_LOG_LEVEL``.
+
+    Applies the env var's level (default ``WARNING``) to the ``miss_alignment``
+    package logger and attaches a stream handler once. Must be called at the
+    start of every process — including spawned training and reconstruction
+    workers — because env vars cross the spawn boundary while runtime logging
+    configuration does not.
+
+    Lightning's INFO startup banners are always silenced (they repeat per rank
+    every macro-iteration and are not controlled by this env var).
+    """
+    level = os.environ.get(LOG_LEVEL_ENV_VAR, "WARNING").upper()
+
+    pkg_logger = logging.getLogger("miss_alignment")
+    pkg_logger.setLevel(level)
+    if not pkg_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(levelname)s | %(name)s | %(message)s")
+        )
+        pkg_logger.addHandler(handler)
+        pkg_logger.propagate = False  # avoid double emission via the root logger
+
+    logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
 
 
 def is_rank_zero() -> bool:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,47 @@
+"""Tests for the shared one-process-per-device work-queue helper."""
+
+import queue
+
+import pytest
+
+from miss_alignment._parallel import run_device_pool
+
+
+def _square_runner(device, task_queue, result_queue):
+    """Process int jobs by squaring them (device is ignored; no CUDA needed)."""
+    while True:
+        try:
+            n = task_queue.get_nowait()
+        except queue.Empty:
+            break
+        result_queue.put_nowait(n * n)
+
+
+def _failing_runner(device, task_queue, result_queue):
+    """Raise on a specific job to exercise worker-failure detection."""
+    while True:
+        try:
+            n = task_queue.get_nowait()
+        except queue.Empty:
+            break
+        if n == 3:
+            raise ValueError("boom")
+        result_queue.put_nowait(n * n)
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_run_device_pool_processes_all_jobs():
+    """Every job is processed exactly once across multiple worker processes."""
+    jobs = [1, 2, 3, 4, 5]
+    results = run_device_pool(
+        jobs, _square_runner, runner_args=(), devices=[0, 1], desc="test"
+    )
+    assert sorted(results) == [1, 4, 9, 16, 25]
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_run_device_pool_raises_on_worker_failure():
+    """A worker that dies with a non-zero exit code surfaces as RuntimeError."""
+    jobs = [1, 2, 3, 4, 5]
+    with pytest.raises(RuntimeError, match="stopped unexpectedly"):
+        run_device_pool(jobs, _failing_runner, runner_args=(), devices=[0], desc="test")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -23,6 +23,7 @@ from miss_alignment.train import (
     _find_free_port,
     _resolve_start_checkpoint,
     _set_ddp_env,
+    _sync_start_iteration_xmls,
 )
 from miss_alignment.utils import is_rank_zero
 
@@ -171,3 +172,37 @@ def test_resolve_start_checkpoint_resume_falls_back(tmp_path):
 def test_resolve_start_checkpoint_resume_missing_returns_none(tmp_path):
     """Resuming with no checkpoint anywhere returns None (regression for #111)."""
     assert _resolve_start_checkpoint(3, tmp_path, None) is None
+
+
+def test_sync_start_iteration_xmls_iter0_backs_up(tmp_path):
+    """iter 0 snapshots the training-directory XMLs into iter0/ (originals kept)."""
+    (tmp_path / "a.xml").write_text("orig-a")
+    (tmp_path / "b.xml").write_text("orig-b")
+
+    _sync_start_iteration_xmls(0, tmp_path)
+
+    assert (tmp_path / "iter0" / "a.xml").read_text() == "orig-a"
+    assert (tmp_path / "iter0" / "b.xml").read_text() == "orig-b"
+    # the working copies are untouched
+    assert (tmp_path / "a.xml").read_text() == "orig-a"
+
+
+def test_sync_start_iteration_xmls_resume_restores(tmp_path):
+    """Resuming overwrites the working XMLs with the iter{N}/ snapshot."""
+    iter_dir = tmp_path / "iter2"
+    iter_dir.mkdir()
+    (iter_dir / "a.xml").write_text("iter2-a")
+    # the training directory holds stale/partial state from a crashed attempt
+    (tmp_path / "a.xml").write_text("stale-a")
+
+    _sync_start_iteration_xmls(2, tmp_path)
+
+    assert (tmp_path / "a.xml").read_text() == "iter2-a"
+    # the snapshot itself is not modified
+    assert (iter_dir / "a.xml").read_text() == "iter2-a"
+
+
+def test_sync_start_iteration_xmls_resume_missing_raises(tmp_path):
+    """Resuming at an iteration with no snapshot directory is an error."""
+    with pytest.raises(FileNotFoundError, match="Cannot resume at iteration 3"):
+        _sync_start_iteration_xmls(3, tmp_path)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -19,7 +19,11 @@ from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.plugins.environments import LightningEnvironment
 from lightning.pytorch.strategies import DDPStrategy
 
-from miss_alignment.train import _find_free_port, _set_ddp_env
+from miss_alignment.train import (
+    _find_free_port,
+    _resolve_start_checkpoint,
+    _set_ddp_env,
+)
 from miss_alignment.utils import is_rank_zero
 
 
@@ -134,3 +138,36 @@ def test_external_launcher_overrides_slurm_detection(tmp_path):
     assert sum(r[1] == "True" for r in rows) == 1  # exactly one recon-pool gate
     assert {r[2] for r in rows} == {"0", "1"}  # our ranks won over SLURM_PROCID=0
     assert {r[3] for r in rows} == {"2"}  # world_size 2, not SLURM_NTASKS=1
+
+
+def test_resolve_start_checkpoint_iter0_uses_config(tmp_path):
+    """iter 0 starts from the config's checkpoint when one is given."""
+    ckpt = tmp_path / "pretrained.ckpt"
+    ckpt.touch()
+    assert _resolve_start_checkpoint(0, tmp_path, str(ckpt)) == ckpt
+
+
+def test_resolve_start_checkpoint_iter0_none(tmp_path):
+    """iter 0 with no config checkpoint trains from scratch."""
+    assert _resolve_start_checkpoint(0, tmp_path, None) is None
+
+
+def test_resolve_start_checkpoint_resume_prefers_iter_dir(tmp_path):
+    """Resuming loads iter{N}/model.ckpt, ignoring the config and the fallback."""
+    (tmp_path / "iter2").mkdir()
+    iter_ckpt = tmp_path / "iter2" / "model.ckpt"
+    iter_ckpt.touch()
+    (tmp_path / "model.ckpt").touch()  # fallback also present
+    assert _resolve_start_checkpoint(2, tmp_path, "ignored.ckpt") == iter_ckpt
+
+
+def test_resolve_start_checkpoint_resume_falls_back(tmp_path):
+    """Resuming uses training_directory/model.ckpt when iter{N}/ is absent."""
+    fallback = tmp_path / "model.ckpt"
+    fallback.touch()
+    assert _resolve_start_checkpoint(3, tmp_path, None) == fallback
+
+
+def test_resolve_start_checkpoint_resume_missing_returns_none(tmp_path):
+    """Resuming with no checkpoint anywhere returns None (regression for #111)."""
+    assert _resolve_start_checkpoint(3, tmp_path, None) is None

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -16,6 +16,7 @@ import torch
 import torch.multiprocessing as torch_mp
 from torch.utils.data import DataLoader, Dataset
 from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch.plugins.environments import LightningEnvironment
 from lightning.pytorch.strategies import DDPStrategy
 
 from miss_alignment.train import _find_free_port
@@ -62,10 +63,25 @@ def _launch_and_train(rank: int, world_size: int, master_port: int, tmp: Path) -
         os.environ["RANK"] = str(rank)
         os.environ["LOCAL_RANK"] = str(rank)
 
+        # Simulate a single-task, non-interactive SLURM allocation: every
+        # spawned worker inherits the SAME SLURM_PROCID=0 / SLURM_NTASKS=1. If
+        # the strategy let Lightning auto-detect SLURMEnvironment, all workers
+        # would collapse to rank 0 of a world of size 1. Pinning
+        # LightningEnvironment (below) must keep our exported ranks authoritative.
+        os.environ["SLURM_NTASKS"] = "1"
+        os.environ["SLURM_PROCID"] = "0"
+        os.environ["SLURM_LOCALID"] = "0"
+        os.environ["SLURM_JOB_NAME"] = "ddp-regression"  # not bash/interactive
+        os.environ["SLURM_JOB_ID"] = "123456"
+
     pre_dist_rank_zero = is_rank_zero()
 
     strategy = (
-        DDPStrategy(process_group_backend="gloo", find_unused_parameters=False)
+        DDPStrategy(
+            cluster_environment=LightningEnvironment(),
+            process_group_backend="gloo",
+            find_unused_parameters=False,
+        )
         if multi
         else "auto"
     )
@@ -99,8 +115,13 @@ def test_single_device_runs_in_process(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_external_launcher_forms_process_group(tmp_path):
-    """``mp.spawn`` + ``LOCAL_RANK``: Lightning attaches, does not re-spawn."""
+def test_external_launcher_overrides_slurm_detection(tmp_path):
+    """``mp.spawn`` + pinned ``LightningEnvironment`` keeps our ranks.
+
+    The workers run with single-task SLURM env vars set, so this also guards the
+    regression where Lightning would auto-detect ``SLURMEnvironment`` and collapse
+    every spawned worker to rank 0 of a world of size 1.
+    """
     world_size = 2
     torch_mp.spawn(
         _launch_and_train,
@@ -115,5 +136,5 @@ def test_external_launcher_forms_process_group(tmp_path):
     assert len(rows) == world_size  # one worker per rank
     assert str(os.getpid()) not in {r[0] for r in rows}  # no re-exec of program
     assert sum(r[1] == "True" for r in rows) == 1  # exactly one recon-pool gate
-    assert {r[2] for r in rows} == {"0", "1"}  # distinct global ranks
-    assert {r[3] for r in rows} == {"2"}  # both saw world_size 2
+    assert {r[2] for r in rows} == {"0", "1"}  # our ranks won over SLURM_PROCID=0
+    assert {r[3] for r in rows} == {"2"}  # world_size 2, not SLURM_NTASKS=1

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -19,7 +19,7 @@ from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.plugins.environments import LightningEnvironment
 from lightning.pytorch.strategies import DDPStrategy
 
-from miss_alignment.train import _find_free_port
+from miss_alignment.train import _find_free_port, _set_ddp_env
 from miss_alignment.utils import is_rank_zero
 
 
@@ -47,7 +47,7 @@ class _TinyModel(LightningModule):
 
 
 def _launch_and_train(rank: int, world_size: int, master_port: int, tmp: Path) -> None:
-    """Stand-in for ``_training_worker`` mirroring its launcher setup on CPU.
+    """Stand-in for ``_training_worker`` reusing its real launcher setup on CPU.
 
     Writes one marker file per rank: ``<pid> <pre_dist_rank0> <global_rank>
     <world_size>``. ``pre_dist_rank0`` is the value of ``is_rank_zero()`` before
@@ -56,12 +56,8 @@ def _launch_and_train(rank: int, world_size: int, master_port: int, tmp: Path) -
     """
     multi = world_size > 1
     if multi:
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = str(master_port)
-        os.environ["WORLD_SIZE"] = str(world_size)
-        os.environ["NODE_RANK"] = "0"
-        os.environ["RANK"] = str(rank)
-        os.environ["LOCAL_RANK"] = str(rank)
+        # exercise the real rendezvous setup from train.py (not a copy)
+        _set_ddp_env(rank, world_size, master_port)
 
         # Simulate a single-task, non-interactive SLURM allocation: every
         # spawned worker inherits the SAME SLURM_PROCID=0 / SLURM_NTASKS=1. If

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,119 @@
+"""Tests for the scoped-DDP launcher mechanism in ``train.py``.
+
+These do not require a GPU. They exercise the part of the training refactor that
+is independent of CUDA: running one worker per rank, acting as the external
+process launcher (exporting ``LOCAL_RANK``) so Lightning attaches to the existing
+process group instead of re-spawning the program, and rank-gating with
+``is_rank_zero()``. The multi-rank case uses ``accelerator="cpu"`` + gloo so it
+runs on a single-GPU (or no-GPU) machine.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+import torch.multiprocessing as torch_mp
+from torch.utils.data import DataLoader, Dataset
+from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch.strategies import DDPStrategy
+
+from miss_alignment.train import _find_free_port
+from miss_alignment.utils import is_rank_zero
+
+
+class _TinyDataset(Dataset):
+    def __len__(self):
+        return 16
+
+    def __getitem__(self, idx):
+        return torch.randn(4), torch.randn(1)
+
+
+class _TinyModel(LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(4, 1)
+
+    def training_step(self, batch, _):
+        x, y = batch
+        loss = ((self.lin(x) - y) ** 2).mean()
+        self.log("train_loss", loss)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=0.01)
+
+
+def _launch_and_train(rank: int, world_size: int, master_port: int, tmp: Path) -> None:
+    """Stand-in for ``_training_worker`` mirroring its launcher setup on CPU.
+
+    Writes one marker file per rank: ``<pid> <pre_dist_rank0> <global_rank>
+    <world_size>``. ``pre_dist_rank0`` is the value of ``is_rank_zero()`` before
+    the process group exists, which is what gates the reconstruction pool in the
+    real datamodule.
+    """
+    multi = world_size > 1
+    if multi:
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(master_port)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["NODE_RANK"] = "0"
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+
+    pre_dist_rank_zero = is_rank_zero()
+
+    strategy = (
+        DDPStrategy(process_group_backend="gloo", find_unused_parameters=False)
+        if multi
+        else "auto"
+    )
+    trainer = Trainer(
+        accelerator="cpu",
+        devices=world_size,
+        strategy=strategy,
+        max_epochs=1,
+        limit_train_batches=2,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
+        num_sanity_val_steps=0,
+    )
+    trainer.fit(_TinyModel(), DataLoader(_TinyDataset(), batch_size=4))
+
+    (tmp / f"rank_{rank}.txt").write_text(
+        f"{os.getpid()} {pre_dist_rank_zero} {trainer.global_rank} {trainer.world_size}"
+    )
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_single_device_runs_in_process(tmp_path):
+    """``world_size == 1`` runs in the calling process with no DDP or spawn."""
+    _launch_and_train(0, 1, _find_free_port(), tmp_path)
+
+    pid, pre_zero, global_rank, world = (tmp_path / "rank_0.txt").read_text().split()
+    assert int(pid) == os.getpid()  # stayed in this process
+    assert pre_zero == "True"  # rank-0 gate -> would spawn the recon pool
+    assert (global_rank, world) == ("0", "1")  # single-process Lightning view
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_external_launcher_forms_process_group(tmp_path):
+    """``mp.spawn`` + ``LOCAL_RANK``: Lightning attaches, does not re-spawn."""
+    world_size = 2
+    torch_mp.spawn(
+        _launch_and_train,
+        args=(world_size, _find_free_port(), tmp_path),
+        nprocs=world_size,
+        join=True,
+    )
+
+    # back in the single parent process; inspect what the workers recorded
+    rows = [m.read_text().split() for m in sorted(tmp_path.glob("rank_*.txt"))]
+
+    assert len(rows) == world_size  # one worker per rank
+    assert str(os.getpid()) not in {r[0] for r in rows}  # no re-exec of program
+    assert sum(r[1] == "True" for r in rows) == 1  # exactly one recon-pool gate
+    assert {r[2] for r in rows} == {"0", "1"}  # distinct global ranks
+    assert {r[3] for r in rows} == {"2"}  # both saw world_size 2


### PR DESCRIPTION
Core refactor — scoped DDP
  - Training phase now runs one mp.spawn worker per GPU, joined per macro-iteration; main process is single-process for alignment (no idle ranks/barriers); removed
  distributed_barrier/rank_zero_print/ddp_timeout_hours. 
  - Pinned LightningEnvironment so SLURM can't hijack the spawned ranks; extracted _set_ddp_env. Tests cover the launcher + SLURM-override.

  Parallelism consolidation
  - Added shared _parallel.run_device_pool (one process per GPU + work queue); migrated prepare-stacks, preprocessing, and alignment onto it; dropped the fixed n_processes knob.
  - Hardened spawned-process cleanup: reconstruction workers daemon=True, bounded/escalating teardown.
  - Capped TORCHINDUCTOR_COMPILE_THREADS to available_cpus // n_training_devices (cpuset/SLURM-aware).

  Resume (#111) fixes
  - Load prior iteration's checkpoint when resuming; training_model_path as single source of truth.
  - Removed pre-loop model.ckpt copy that crashed resume (SameFileError).
  - On resume, restore working XMLs from iter{N}/ (back up only at iter 0). Helpers _resolve_start_checkpoint/_sync_start_iteration_xmls unit-tested.

  Logging / output cleanup
  - MISS_ALIGNMENT_LOG_LEVEL env var (worker-aware); muted Lightning INFO banners (both lightning.pytorch + lightning.fabric); explicit TensorBoard logger; recon lifecycle → debug;
  silenced repeated seed/model-summary prints.
  - Progress bars always shown; device output grouped by macro-iteration phase.

  Docs
  - CLAUDE.md: macro-iteration/scoped-DDP rationale, stable multi-lab framing, trimmed global-overlap.
  - docs/usage.md: single-task SLURM, log level, compile-threads notes.


This makes PR #113 obsolete
closes #115 
closes #111