### PR TITLE
Fix division by zero in subvolume normalization

### DIFF
--- a/src/miss_alignment/alignment/optimize_global.py
+++ b/src/miss_alignment/alignment/optimize_global.py
@@ -401,9 +401,7 @@ def _optimize_shifts_inner(
                 # ensure normalization per subvolume
                 mean = einops.reduce(subvolumes, "n d h w -> n 1 1 1", reduction="mean")
                 std = torch.std(subvolumes, dim=(-3, -2, -1), keepdim=True)
-                # Add epsilon to prevent division by zero (which causes NaN precision)
-                eps = 1e-8
-                subvolumes = (subvolumes - mean) / (std + eps)
+                subvolumes = (subvolumes - mean) / std.clamp(min=1e-6)
 
                 # change channel to batch dimension
                 subvolumes = einops.rearrange(subvolumes, "b d h w -> b 1 d h w")

--- a/src/miss_alignment/alignment/optimize_spline.py
+++ b/src/miss_alignment/alignment/optimize_spline.py
@@ -263,9 +263,7 @@ def _optimize_shifts_spline_inner(
 
                 mean = einops.reduce(subvolumes, "n d h w -> n 1 1 1", reduction="mean")
                 std = torch.std(subvolumes, dim=(-3, -2, -1), keepdim=True)
-                # Add epsilon to prevent division by zero (which causes NaN precision)
-                eps = 1e-8
-                subvolumes = (subvolumes - mean) / (std + eps)
+                subvolumes = (subvolumes - mean) / std.clamp(min=1e-6)
                 subvolumes = einops.rearrange(subvolumes, "b d h w -> b 1 d h w")
 
                 # Get score and precision for this batch

--- a/src/miss_alignment/data/training_dataset.py
+++ b/src/miss_alignment/data/training_dataset.py
@@ -143,8 +143,4 @@ class ReconstructionPoolDataset(Dataset):
 
     def _normalize(self, volume: torch.Tensor) -> torch.Tensor:
         mean, std = torch.mean(volume), torch.std(volume)
-        if std == 0.0:
-            raise ValueError(
-                "Cannot normalize patch because the standard deviation is 0."
-            )
-        return (volume - mean) / std
+        return (volume - mean) / std.clamp(min=1e-6)

--- a/tests/data/test_pool_dataset.py
+++ b/tests/data/test_pool_dataset.py
@@ -171,11 +171,10 @@ class TestReconstructionPoolDataset:
         assert torch.abs(torch.std(normalized) - 1.0) < 1e-6
 
     def test_normalize_constant_volume(self, dataset):
-        """Test normalization with constant volume (std=0)."""
+        """Test normalization with constant volume (std=0) returns zeros."""
         volume = torch.ones(10)
-
-        with pytest.raises(ValueError):
-            dataset._normalize(volume)
+        result = dataset._normalize(volume)
+        assert torch.all(result == 0.0)
 
     @patch("miss_alignment.data.training_dataset.random_contrast")
     @patch("miss_alignment.data.training_dataset.random_edge_mask")

--- a/tests/data/test_pool_dataset.py
+++ b/tests/data/test_pool_dataset.py
@@ -176,6 +176,12 @@ class TestReconstructionPoolDataset:
         result = dataset._normalize(volume)
         assert torch.all(result == 0.0)
 
+    def test_normalize_near_zero_std(self, dataset):
+        """Test normalization with near-zero std produces finite values."""
+        volume = torch.ones(10) + torch.randn(10) * 1e-9
+        result = dataset._normalize(volume)
+        assert torch.all(torch.isfinite(result))
+
     @patch("miss_alignment.data.training_dataset.random_contrast")
     @patch("miss_alignment.data.training_dataset.random_edge_mask")
     @patch("miss_alignment.data.training_dataset.random_cube_mask")


### PR DESCRIPTION
## Summary

- Replaces `(std + 1e-8)` with `std.clamp(min=1e-6)` in alignment normalization (`optimize_global.py`, `optimize_spline.py`) to prevent cancellation when `std` is slightly negative due to float32 rounding
- Replaces the `ValueError` on zero std in `ReconstructionPoolDataset._normalize` with `std.clamp(min=1e-6)`, silently handling near-constant patches instead of crashing

Closes #78
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)