### PR TITLE
Fix anchor mirror selection in reconstruction augmentation

### DIFF
--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -381,11 +381,11 @@ def _create_pool_reconstruction(
         anchor_base = misaligned.clone()
         anchor_label = -1
 
-    # Generate 2 triplets with all mirror combinations
+    # Generate 2 triplets with randomly sampled mirror combinations code samples two mirror combinations rather than all eight
     triplets = []
     for i_batch in range(n_particles):
         combinations_subset = random.sample(MIRROR_COMBINATIONS, 2)
-        for i, mirror_combo in enumerate(combinations_subset):
+        for mirror_combo in combinations_subset:
             # Apply same mirror to positive and negative
             mirrored_aligned = apply_mirror(
                 aligned[i_batch].clone(), mirror_combo
@@ -395,7 +395,7 @@ def _create_pool_reconstruction(
             ).cpu()
 
             # Pick a different mirror for anchor
-            other_combos = [c for j, c in enumerate(MIRROR_COMBINATIONS) if j != i]
+            other_combos = [c for c in MIRROR_COMBINATIONS if c != mirror_combo]
             anchor_mirror = random.choice(other_combos)
             mirrored_anchor = apply_mirror(
                 anchor_base[i_batch].clone(), anchor_mirror

--- a/src/miss_alignment/data/_reconstruction_worker.py
+++ b/src/miss_alignment/data/_reconstruction_worker.py
@@ -381,20 +381,20 @@ def _create_pool_reconstruction(
         anchor_base = misaligned.clone()
         anchor_label = -1
 
-    # Generate 2 triplets with randomly sampled mirror combinations code samples two mirror combinations rather than all eight
+    # create more triplets by applying mirroring augmentation
+    # positive and negative always share the same mirror
+    # anchor always has a different mirror
     triplets = []
     for i_batch in range(n_particles):
         combinations_subset = random.sample(MIRROR_COMBINATIONS, 2)
         for mirror_combo in combinations_subset:
-            # Apply same mirror to positive and negative
             mirrored_aligned = apply_mirror(
                 aligned[i_batch].clone(), mirror_combo
             ).cpu()
             mirrored_misaligned = apply_mirror(
                 misaligned[i_batch].clone(), mirror_combo
             ).cpu()
-
-            # Pick a different mirror for anchor
+            
             other_combos = [c for c in MIRROR_COMBINATIONS if c != mirror_combo]
             anchor_mirror = random.choice(other_combos)
             mirrored_anchor = apply_mirror(


### PR DESCRIPTION
## Summary

This PR proposes a small fix to the mirror augmentation logic in
`src/miss_alignment/data/_reconstruction_worker.py`.

The function docstring says:

> Positive and negative examples share the same mirror, anchor has a different mirror.

The current implementation samples two mirror combinations:

```python
combinations_subset = random.sample(MIRROR_COMBINATIONS, 2)
for i, mirror_combo in enumerate(combinations_subset):
```
but then chooses anchor mirror candidates using:
```
other_combos = [c for j, c in enumerate(MIRROR_COMBINATIONS) if j != i]
```
i is the index within the two-element combinations_subset, not the index of the selected mirror_combo within MIRROR_COMBINATIONS. As a result, the anchor mirror candidate list excludes MIRROR_COMBINATIONS[0] or MIRROR_COMBINATIONS[1], rather than excluding the actual mirror_combo used for the positive/negative pair.

## Proposed change
This PR changes the anchor candidate selection to exclude the selected mirror combination directly:
```
other_combos = [c for c in MIRROR_COMBINATIONS if c != mirror_combo]
```
It also removes the now-unused i loop variable.

The  augmentation appears to enforce mirror/orientation invariance by making the positive and negative examples share the same mirror while the anchor uses a different mirror. With the current indexing logic, the anchor can sometimes receive the same mirror as the positive/negative pair, which weakens that augmentation constraint and biases the anchor mirror distribution.

## Scope
This PR is intentionally minimal. It does not change the reconstruction logic, labels, shift generation, training loop, or CLI behavior.

## Testing

Not run locally; proposed based on code inspection.