### PR TITLE
Raise FileNotFoundError when XML metadata file is missing

### DIFF
--- a/src/miss_alignment/data/io.py
+++ b/src/miss_alignment/data/io.py
@@ -65,6 +65,9 @@ def _load_metadata_and_stack(
     downsample: int = 1,
     retry_on_read_error: bool = False,
 ) -> tuple[TiltSeries, torch.Tensor, float]:
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"XML metadata file not found: {metadata_path}")
+
     # load metadata
     tilt_series = TiltSeries(metadata_path)
     _validate_tilt_series_dimensions(tilt_series, metadata_path)

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -131,6 +131,17 @@ class TestTiltSeriesData:
         assert loaded_images.shape[1] == 50
         assert loaded_images.shape[2] == 50
 
+    def test_load_metadata_and_stack_missing_xml_raises(self, tmp_path):
+        """Loading a non-existent XML file raises FileNotFoundError."""
+        xml_path = tmp_path / "does_not_exist.xml"
+
+        data = TiltSeriesData(
+            xml_metadata_path=xml_path,
+        )
+
+        with pytest.raises(FileNotFoundError, match="does_not_exist.xml"):
+            data.load_metadata_and_stack()
+
 
 class TestRetryOnReadError:
     """Tests for the retry_on_read_error flag in load_metadata_and_stack."""


### PR DESCRIPTION
## Summary
- `TiltSeriesData.load_metadata_and_stack()` (used across alignment, reconstruction, and preprocessing) called `warpylib.TiltSeries(path)` without checking the path exists. warpylib doesn't error on a missing file — it silently constructs an empty `TiltSeries` (zero-filled dimensions, no angles). Downstream this surfaced as a confusing `ValueError: ... has zero values in 'ImageDimensionsAngstrom'` instead of pointing at the real problem.
- Added an explicit existence check in `_load_metadata_and_stack` that raises `FileNotFoundError` naming the missing path before any load is attempted.

Fixes #126.

## Test plan
- [x] Added `test_load_metadata_and_stack_missing_xml_raises` in `tests/data/test_io.py`
- [x] `pytest tests/data/` (132 passed)
- [x] `ruff check` / `ruff format --check`