### PR TITLE
Closes #132.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install torch-projectors (CPU)
         run: |
-          python -m pip install torch-projectors --index-url https://warpem.github.io/torch-projectors/cpu/simple/
+          python -m pip install torch-projectors
 
       - name: Install package
         run: python -m pip install -e .[test]

--- a/src/miss_alignment/data/io.py
+++ b/src/miss_alignment/data/io.py
@@ -3,6 +3,7 @@ import time
 import torch
 import mrcfile
 from pathlib import Path
+from shutil import move
 
 from warpylib import TiltSeries
 from warpylib.ops import rescale
@@ -58,6 +59,62 @@ def _validate_tilt_series_dimensions(tilt_series: TiltSeries, path: Path) -> Non
             f"XML metadata at {path} has zero values in "
             f"'VolumeDimensionsAngstrom': {volume_dims.tolist()}"
         )
+
+
+_ALIGNMENT_FIELDS = (
+    "angles",
+    "tilt_axis_angles",
+    "tilt_axis_offset_x",
+    "tilt_axis_offset_y",
+)
+
+
+def _nonfinite_alignment_fields(tilt_series: TiltSeries) -> list[str]:
+    """Return the names of alignment fields that contain NaN/Inf values."""
+    bad = []
+    for name in _ALIGNMENT_FIELDS:
+        value = getattr(tilt_series, name, None)
+        if value is None:
+            continue
+        tensor = torch.as_tensor(value)
+        if tensor.numel() > 0 and not torch.isfinite(tensor).all():
+            bad.append(name)
+    return bad
+
+
+def exclude_nonfinite_alignment_tilt_series(training_directory: Path) -> list[Path]:
+    """Move tilt-series with unusable alignment metadata out of the training set."""
+    excluded = []
+    for xml_file in sorted(training_directory.glob("*.xml")):
+        try:
+            tilt_series = TiltSeries(xml_file)
+        except Exception as error:
+            excluded.append((xml_file, f"unparseable XML ({type(error).__name__})"))
+            continue
+        bad_fields = _nonfinite_alignment_fields(tilt_series)
+        if bad_fields:
+            excluded.append((xml_file, f"non-finite alignment in {bad_fields}"))
+
+    if excluded:
+        quarantine = training_directory / "excluded_nonfinite_alignment"
+        quarantine.mkdir(parents=True, exist_ok=True)
+        for xml_file, reason in excluded:
+            print(f"WARNING: excluding '{xml_file.name}' -- {reason}.", flush=True)
+            move(str(xml_file), str(quarantine / xml_file.name))
+
+    remaining = list(training_directory.glob("*.xml"))
+    if not remaining:
+        raise ValueError(
+            f"No tilt-series with usable alignment metadata remain in "
+            f"{training_directory} (excluded {len(excluded)})."
+        )
+    if excluded:
+        print(
+            f"Excluded {len(excluded)} tilt-series with unusable alignment; "
+            f"{len(remaining)} remain for training.",
+            flush=True,
+        )
+    return [xml_file for xml_file, _ in excluded]
 
 
 def _load_metadata_and_stack(

--- a/src/miss_alignment/infer.py
+++ b/src/miss_alignment/infer.py
@@ -12,6 +12,7 @@ from lightning.pytorch import seed_everything
 
 from ._cli import OPTION_PROMPT_KWARGS, cli
 from .utils import configure_logging, sync_start_iteration_xmls
+from .data.io import exclude_nonfinite_alignment_tilt_series
 from .alignment import run_alignment_parallel
 from .prepare_stacks import prepare_stacks_parallel
 from .preprocessing import run_cross_correlation_alignment_parallel
@@ -113,6 +114,8 @@ def infer_miss_align(
             training_directory=data_directory,
             devices=devices_alignment,
         )
+
+    exclude_nonfinite_alignment_tilt_series(data_directory)
 
     start_iter = start_at_iteration
     end_iter = len(general_config["iteration_settings"])

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -20,6 +20,7 @@ from lightning.pytorch.strategies import DDPStrategy
 from ._cli import OPTION_PROMPT_KWARGS, cli
 from .utils import configure_logging, parse_device_list, sync_start_iteration_xmls
 from .data import MissAlignmentDataModule
+from .data.io import exclude_nonfinite_alignment_tilt_series
 from .data.shift_generation import create_default_generator
 from .models import MissAlignment, MAEarlyStopping, MAProgressBar
 from .alignment import run_alignment_parallel
@@ -411,6 +412,8 @@ def train_miss_align(
                 training_directory=training_directory,
                 devices=devices_alignment,
             )
+
+    exclude_nonfinite_alignment_tilt_series(training_directory)
 
     start_iter = start_at_iteration
     end_iter = len(general_config["iteration_settings"])


### PR DESCRIPTION
A tilt-series XML can carry NaN/Inf alignment values when an upstream alignment (AreTomo, patch-tracking) fails without being flagged. This shouldn't ever happen but sometimes it does - it did for me in 1 out of 55 datasets. `_validate_tilt_series_dimensions` doesn't catch this, so the NaN propagates into the training loss whenever the corrupted tilt series is sampled.

This PR adds a check for NaNs during the initialization stage of training. It scans every XML, moves any tilt-series with corrupted alignments into `<training_directory>/excluded_nonfinite_alignment/`, and prints how many were skipped and how many remain (raising only if none remain). Every step re-globs `training_directory/*.xml`, so moving the offenders out leaves them out everywhere (training and the alignment step).