### PR TITLE
Refactor cross-correlation functions to remove pretilt search range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install torch-projectors (CPU)
         run: |
-          python -m pip install torch-projectors --index-url https://warpem.github.io/torch-projectors/cpu/simple/
+          python -m pip install torch-projectors
 
       - name: Install package
         run: python -m pip install -e .[test]

--- a/src/miss_alignment/infer.py
+++ b/src/miss_alignment/infer.py
@@ -37,7 +37,7 @@ def infer_miss_align(
     preprocess: bool = typer.Option(
         False,
         help="Run cross-correlation based alignment before the inference "
-        "iterations. This performs coarse alignment with pretilt estimation.",
+        "iterations. This performs coarse alignment.",
     ),
 ) -> None:
     """Align a dataset by applying models from a previous training run.

--- a/src/miss_alignment/preprocessing.py
+++ b/src/miss_alignment/preprocessing.py
@@ -12,7 +12,7 @@ def _run_cross_correlation_single(
     xml_file: Path,
     device: int | None,
     lowpass_cutoff: float,
-) -> float:
+) -> None:
     """Run cross-correlation alignment on a single tilt-series.
 
     Parameters
@@ -23,13 +23,6 @@ def _run_cross_correlation_single(
         CUDA device index to use. If None, uses default device.
     lowpass_cutoff : float
         Low-pass filter cutoff frequency.
-    pretilt_search_range : tuple[float, float]
-        Search range for pretilt estimation in degrees.
-
-    Returns
-    -------
-    float
-        The estimated pretilt value in degrees.
     """
     from torch_tiltxcorr import tiltxcorr
 
@@ -46,13 +39,13 @@ def _run_cross_correlation_single(
     # Extract tilt axis angle from metadata (same for all tilts)
     tilt_axis_angle = ts.tilt_axis_angles[0].item()
 
-    # Run cross-correlation alignment with pretilt estimation
-    shifts = tiltxcorr_with_sample_tilt_estimation(
+    # Run cross-correlation alignment
+    shifts = tiltxcorr(
         tilt_series=stack.to(device_str),
         tilt_angles=ts.angles.to(device_str),
         tilt_axis_angle=tilt_axis_angle,
         pixel_spacing_angstroms=pixel_size,
-        lowpass_angstroms=pixel_size / lowpass_cutoff
+        lowpass_angstroms=pixel_size / lowpass_cutoff,
     )
 
     # Convert shifts from pixels to Angstroms
@@ -68,10 +61,7 @@ def _run_cross_correlation_single(
 
 
 def _cross_correlation_runner(
-    device: int | None,
-    task_queue,
-    result_queue,
-    lowpass_cutoff: float
+    device: int | None, task_queue, result_queue, lowpass_cutoff: float
 ) -> None:
     """Pull tilt-series off the queue and align them on a single device."""
 
@@ -82,7 +72,9 @@ def _cross_correlation_runner(
         except queue.Empty:
             break
         _run_cross_correlation_single(
-            xml_file, device, lowpass_cutoff,
+            xml_file,
+            device,
+            lowpass_cutoff,
         )
         result_queue.put_nowait(xml_file.stem)
 
@@ -90,13 +82,13 @@ def _cross_correlation_runner(
 def run_cross_correlation_alignment_parallel(
     training_directory: Path,
     devices: list[int] | None = None,
-    lowpass_cutoff: float = 0.25
+    lowpass_cutoff: float = 0.25,
 ) -> None:
     """
-    Run cross-correlation based alignment with pretilt estimation in parallel.
+    Run cross-correlation based alignment in parallel.
 
     This performs coarse alignment using cross-correlation to estimate shifts
-    for all tilt-series in the training directory, processing multiple 
+    for all tilt-series in the training directory, processing multiple
     tilt-series in parallel across available GPUs.
 
     Parameters

--- a/src/miss_alignment/preprocessing.py
+++ b/src/miss_alignment/preprocessing.py
@@ -1,6 +1,7 @@
 """Preprocessing utilities for tilt-series alignment."""
 
 import queue
+import torch
 from pathlib import Path
 
 from ._parallel import run_device_pool
@@ -11,7 +12,6 @@ def _run_cross_correlation_single(
     xml_file: Path,
     device: int | None,
     lowpass_cutoff: float,
-    pretilt_search_range: tuple[float, float],
 ) -> float:
     """Run cross-correlation alignment on a single tilt-series.
 
@@ -31,8 +31,7 @@ def _run_cross_correlation_single(
     float
         The estimated pretilt value in degrees.
     """
-    import torch
-    from torch_tiltxcorr import tiltxcorr_with_sample_tilt_estimation
+    from torch_tiltxcorr import tiltxcorr
 
     if device is not None and torch.cuda.is_available():
         torch.cuda.set_device(device)
@@ -48,20 +47,16 @@ def _run_cross_correlation_single(
     tilt_axis_angle = ts.tilt_axis_angles[0].item()
 
     # Run cross-correlation alignment with pretilt estimation
-    shifts, pretilt = tiltxcorr_with_sample_tilt_estimation(
+    shifts = tiltxcorr_with_sample_tilt_estimation(
         tilt_series=stack.to(device_str),
         tilt_angles=ts.angles.to(device_str),
         tilt_axis_angle=tilt_axis_angle,
         pixel_spacing_angstroms=pixel_size,
-        lowpass_angstroms=pixel_size / lowpass_cutoff,
-        sample_tilt_range=pretilt_search_range,
+        lowpass_angstroms=pixel_size / lowpass_cutoff
     )
 
     # Convert shifts from pixels to Angstroms
     shifts_angstrom = shifts * pixel_size
-
-    # Apply pretilt to angles
-    ts.angles = ts.angles + pretilt
 
     # Apply shifts (note: negation and axis assignment)
     # shifts are in YX order, tilt_axis_offset are X and Y
@@ -71,18 +66,14 @@ def _run_cross_correlation_single(
     # Save updated metadata
     ts_data.save_metadata_to_xml(ts)
 
-    return float(pretilt)
-
 
 def _cross_correlation_runner(
     device: int | None,
     task_queue,
     result_queue,
-    lowpass_cutoff: float,
-    pretilt_search_range: tuple[float, float],
+    lowpass_cutoff: float
 ) -> None:
     """Pull tilt-series off the queue and align them on a single device."""
-    import torch
 
     torch.set_num_threads(1)
     while True:
@@ -91,7 +82,7 @@ def _cross_correlation_runner(
         except queue.Empty:
             break
         _run_cross_correlation_single(
-            xml_file, device, lowpass_cutoff, pretilt_search_range
+            xml_file, device, lowpass_cutoff,
         )
         result_queue.put_nowait(xml_file.stem)
 
@@ -99,15 +90,14 @@ def _cross_correlation_runner(
 def run_cross_correlation_alignment_parallel(
     training_directory: Path,
     devices: list[int] | None = None,
-    lowpass_cutoff: float = 0.25,
-    pretilt_search_range: tuple[float, float] = (-30.0, 30.0),
+    lowpass_cutoff: float = 0.25
 ) -> None:
     """
     Run cross-correlation based alignment with pretilt estimation in parallel.
 
     This performs coarse alignment using cross-correlation to estimate shifts
-    and sample pretilt (initial tilt offset) for all tilt-series in the training
-    directory, processing multiple tilt-series in parallel across available GPUs.
+    for all tilt-series in the training directory, processing multiple 
+    tilt-series in parallel across available GPUs.
 
     Parameters
     ----------
@@ -118,8 +108,6 @@ def run_cross_correlation_alignment_parallel(
         unique device). If None, a single default-device worker is used.
     lowpass_cutoff : float, optional
         Low-pass filter cutoff frequency (default: 0.25).
-    pretilt_search_range : tuple[float, float], optional
-        Search range for pretilt estimation in degrees (default: (-30.0, 30.0)).
     """
     # Get list of all XML files to process
     xml_files = list(training_directory.glob("*.xml"))
@@ -128,10 +116,6 @@ def run_cross_correlation_alignment_parallel(
         raise ValueError(f"No XML files found in {training_directory}")
 
     print(f"\nRunning cross-correlation alignment on {len(xml_files)} tilt-series...")
-    print(
-        f"  Pretilt search range: "
-        f"{pretilt_search_range[0]}° to {pretilt_search_range[1]}°"
-    )
     print(f"  Low-pass cutoff: {lowpass_cutoff}")
     if devices:
         print(f"  Distributing across devices: {devices}\n")
@@ -141,7 +125,7 @@ def run_cross_correlation_alignment_parallel(
     run_device_pool(
         jobs=xml_files,
         runner=_cross_correlation_runner,
-        runner_args=(lowpass_cutoff, pretilt_search_range),
+        runner_args=(lowpass_cutoff,),
         devices=devices,
         desc="Cross-correlation alignment",
     )

--- a/src/miss_alignment/train.py
+++ b/src/miss_alignment/train.py
@@ -308,7 +308,7 @@ def train_miss_align(
     preprocess: bool = typer.Option(
         False,
         help="Run cross-correlation based alignment before training iterations. "
-        "This performs coarse alignment with pretilt estimation.",
+        "This performs coarse alignment.",
     ),
 ) -> None:
     """Iteratively train and realign a dataset over a series of coarse-to-fine


### PR DESCRIPTION
Removed pretilt_search_range parameter and related code from cross-correlation functions. Updated function calls and documentation accordingly.

The auto_zero command in WarpTools is much more reliable at finding pre-tilt, so I thought we should just remove it here. If the tilt axis angle is known and the pre-tilt corrected, this xcorr function is really good at getting initial alignments.