### PR TITLE
Refactor log precision calculations in models.py

### DIFF
--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -72,8 +72,9 @@ class TripletMarginRankingLoss(nn.Module):
             (triplet_loss, precision_reg) - weighted triplet loss and precision
             regularization term
         """
-        # Convert log precision to precision (always positive)
-        precisions = log_precisions.exp()
+        # Bound log precision element-wise: saturated triplets contribute zero
+        # gradient to their own log precision, so nothing else holds it finite
+        log_precisions = log_precisions.clamp(-10.0, 10.0)
 
         # Identify example types and compute distances
         example_type = einops.rearrange(triplet_indices.sum(dim=-1), "b -> b 1")
@@ -86,12 +87,6 @@ class TripletMarginRankingLoss(nn.Module):
         distant_scores = scores[distant_mask]  # (b,)
         distant_scores = einops.rearrange(distant_scores, "b -> b 1")
 
-        # Extract precisions for weighting
-        close_precisions = precisions[close_mask]
-        close_precisions = einops.rearrange(close_precisions, "(b n) -> b n", n=2)
-        distant_precisions = precisions[distant_mask]
-        distant_precisions = einops.rearrange(distant_precisions, "b -> b 1")
-
         # Compute distances
         dist_pos = torch.abs(close_scores[..., 0] - close_scores[..., 1])
         dist_neg = torch.min(
@@ -103,13 +98,14 @@ class TripletMarginRankingLoss(nn.Module):
 
         # Weight by geometric mean of precisions in the triplet
         # This downweights triplets where any member has low precision
-        all_precisions = torch.cat([close_precisions, distant_precisions], dim=-1)
-        triplet_precision = all_precisions.prod(dim=-1).pow(1 / 3)  # geometric mean
+        triplet_precision = log_precisions.mean(dim=-1).exp()
         weighted_losses = triplet_losses * triplet_precision
 
         # Precision regularization: penalize low precision to prevent collapse
-        # Using mean of log_precisions (equivalent to log of geometric mean)
-        precision_reg = -log_precisions.mean() * self.precision_reg_weight
+        # One-sided: penalizes collapse without rewarding unbounded precision
+        precision_reg = (
+            torch.clamp(-log_precisions.mean(), min=0.0) * self.precision_reg_weight
+        )
 
         # Apply reduction to weighted losses
         if self.reduction == "mean":

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -72,10 +72,6 @@ class TripletMarginRankingLoss(nn.Module):
             (triplet_loss, precision_reg) - weighted triplet loss and precision
             regularization term
         """
-        # Bound log precision element-wise: saturated triplets contribute zero
-        # gradient to their own log precision, so nothing else holds it finite
-        log_precisions = log_precisions.clamp(-10.0, 10.0)
-
         # Identify example types and compute distances
         example_type = einops.rearrange(triplet_indices.sum(dim=-1), "b -> b 1")
         close_mask = triplet_indices == example_type
@@ -96,16 +92,15 @@ class TripletMarginRankingLoss(nn.Module):
         # Compute triplet loss with margin
         triplet_losses = F.relu(dist_pos + dist_neg + self.margin)
 
-        # Weight by geometric mean of precisions in the triplet
-        # This downweights triplets where any member has low precision
-        triplet_precision = log_precisions.mean(dim=-1).exp()
-        weighted_losses = triplet_losses * triplet_precision
+        # Weight by softmax over the log-space geometric mean of precisions;
+        # shift-invariant and bounded, so no single triplet can dominate.
+        log_triplet_precision = log_precisions.mean(dim=-1)  # log geometric mean
+        weights = torch.softmax(log_triplet_precision, dim=0)
+        weighted_losses = triplet_losses * weights * triplet_losses.shape[0]
 
-        # Precision regularization: penalize low precision to prevent collapse
-        # One-sided: penalizes collapse without rewarding unbounded precision
-        precision_reg = (
-            torch.clamp(-log_precisions.mean(), min=0.0) * self.precision_reg_weight
-        )
+        # Quadratic prior pins log precision at 0 (softmax is shift-invariant,
+        # so nothing else constrains its absolute level).
+        precision_reg = 0.5 * log_precisions.pow(2).mean() * self.precision_reg_weight
 
         # Apply reduction to weighted losses
         if self.reduction == "mean":
@@ -180,8 +175,9 @@ class MissAlignment(pl.LightningModule):
         score_aligned = torch.mean(scores[target == 1])
         score_misaligned = torch.mean(scores[target == -1])
 
-        # Compute mean precision for logging
+        # Compute mean and spread of log precision for logging
         mean_log_precision = log_precisions.mean()
+        std_log_precision = log_precisions.std()
 
         return (
             total_loss,
@@ -191,6 +187,7 @@ class MissAlignment(pl.LightningModule):
             score_aligned,
             score_misaligned,
             mean_log_precision,
+            std_log_precision,
         )
 
     def training_step(
@@ -206,6 +203,7 @@ class MissAlignment(pl.LightningModule):
             score_aligned,
             score_misaligned,
             mean_log_precision,
+            std_log_precision,
         ) = self._common_step(batch, batch_idx)
 
         # Fail fast on NaN loss to prevent corrupted training
@@ -271,6 +269,18 @@ class MissAlignment(pl.LightningModule):
             name="mean_log_precision",
             value=mean_log_precision.item(),
             prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+            logger=True,
+            sync_dist=True,
+        )
+
+        # Log precision spread: rising values mean the softmax weighting is
+        # approaching one-hot, letting a single triplet dominate the batch
+        self.log(
+            name="std_log_precision",
+            value=std_log_precision.item(),
+            prog_bar=False,
             on_step=False,
             on_epoch=True,
             logger=True,

--- a/src/miss_alignment/models/models.py
+++ b/src/miss_alignment/models/models.py
@@ -181,7 +181,7 @@ class MissAlignment(pl.LightningModule):
         score_misaligned = torch.mean(scores[target == -1])
 
         # Compute mean precision for logging
-        mean_precision = log_precisions.exp().mean()
+        mean_log_precision = log_precisions.mean()
 
         return (
             total_loss,
@@ -190,7 +190,7 @@ class MissAlignment(pl.LightningModule):
             batch_size,
             score_aligned,
             score_misaligned,
-            mean_precision,
+            mean_log_precision,
         )
 
     def training_step(
@@ -205,7 +205,7 @@ class MissAlignment(pl.LightningModule):
             batch_size,
             score_aligned,
             score_misaligned,
-            mean_precision,
+            mean_log_precision,
         ) = self._common_step(batch, batch_idx)
 
         # Fail fast on NaN loss to prevent corrupted training
@@ -268,8 +268,8 @@ class MissAlignment(pl.LightningModule):
 
         # Log mean precision to monitor uncertainty learning
         self.log(
-            name="mean_precision",
-            value=mean_precision.item(),
+            name="mean_log_precision",
+            value=mean_log_precision.item(),
             prog_bar=True,
             on_step=False,
             on_epoch=True,


### PR DESCRIPTION
@dtegunov, it would be good if you could take a look at this PR.
I ran into a pretty severe bug in the confidence mechanism. I have only noticed this once so far and I think its due to a dataset with pretty high SNR. Essentially I noticed big swings in the loss and spikes in the precision. Apparently the old code only punished the model for being too unsure, which meant that if the training got to a point where it could easily distinguish bad from good alignment it could maximize the loss by hugely inflating the confidence. 

With this fix, confidences in a batch now get split into 'shares of a pie', they need to add up to 100%. And the updated regularizer keeps the confidence around neutral.

Maybe this is the reason why dutkap had problems on this one dataset, because it was also very clean in signal.
